### PR TITLE
use a RegExp to test output from `git branch`

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -144,7 +144,8 @@ describe('Branch validation', function () {
             })
             .catch(function (err) {
                 assert(err instanceof PluginError);
-                assert.strictEqual(err.message, '  * Expected branch to be `master`, but it was `(detached from a4b76ae)`.');
+                var re = /^  \* Expected branch to be `master`, but it was `\((?:HEAD )?detached (?:from|at) a4b76ae\)`.$/;
+                assert(re.test(err.message))
             });
     });
 


### PR DESCRIPTION
This is an attempt to address #6 .

I've tested the RegExp against both the hardcoded string from git <2.4.0 output, as well as the output from my git 2.6.4 installation.