### PR TITLE
npm should use the local mocha when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=4.0.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If you don't have mocha installed globally,  then running `npm test` will fail.  this points to the local mocha in node_modules