### PR TITLE
If prepublishScript was specified make sure package.json is read afte…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,25 +148,23 @@ module.exports = function (opts) {
     let pkgInfo = null;
 
     opts = getOptions(opts);
-
-    return pkgd()
-        .then(info => {
-
-            pkgInfo = info;
-
-            if (opts.prepublishScript)
-                return runPrepublishScript(opts.prepublishScript);
-        })
-        .then(() => runValidations(opts, pkgInfo))
-        .then(() => {
-            if (!module.exports.testMode)
-                return printReleaseInfo(pkgInfo.cfg.version, opts.tag);
-        })
-        .then(() => opts.confirm ? confirmPublish() : true)
-        .then(ok => {
-            if (ok)
-                return publish(opts.tag);
-        });
+    return (opts.prepublishScript
+        ? runPrepublishScript(opts.prepublishScript)
+        : Promise.resolve())
+    .then(pkgd)
+    .then(info => {
+        pkgInfo = info;
+    })
+    .then(() => runValidations(opts, pkgInfo))
+    .then(() => {
+        if (!module.exports.testMode)
+            return printReleaseInfo(pkgInfo.cfg.version, opts.tag);
+    })
+    .then(() => opts.confirm ? confirmPublish() : true)
+    .then(ok => {
+        if (ok)
+            return publish(opts.tag);
+    });
 };
 
 // Exports for the testing purposes

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,23 +148,26 @@ module.exports = function (opts) {
     let pkgInfo = null;
 
     opts = getOptions(opts);
-    return (opts.prepublishScript
-        ? runPrepublishScript(opts.prepublishScript)
-        : Promise.resolve())
-    .then(pkgd)
-    .then(info => {
-        pkgInfo = info;
-    })
-    .then(() => runValidations(opts, pkgInfo))
-    .then(() => {
-        if (!module.exports.testMode)
-            return printReleaseInfo(pkgInfo.cfg.version, opts.tag);
-    })
-    .then(() => opts.confirm ? confirmPublish() : true)
-    .then(ok => {
-        if (ok)
-            return publish(opts.tag);
-    });
+
+    return Promise.resolve()
+        .then(() => {
+            if (opts.prepublishScript)
+                return runPrepublishScript(opts.prepublishScript);
+        })
+        .then(pkgd)
+        .then(info => {
+            pkgInfo = info;
+        })
+        .then(() => runValidations(opts, pkgInfo))
+        .then(() => {
+            if (!module.exports.testMode)
+                return printReleaseInfo(pkgInfo.cfg.version, opts.tag);
+        })
+        .then(() => opts.confirm ? confirmPublish() : true)
+        .then(ok => {
+            if (ok)
+                return publish(opts.tag);
+        });
 };
 
 // Exports for the testing purposes


### PR DESCRIPTION
Hi Ivan,

I have a prepublishScript that does tagging through `npm version`, which automatically updates `version` field in `package.json`. When `publish-please` starts validation there's always mismatch between versions, it's because `pkgd()` runs before prepublishScript thus has outdated information.

Thank you!