### PR TITLE
Explicitly ask git branch not to use colors

### DIFF
--- a/src/validations/branch.js
+++ b/src/validations/branch.js
@@ -18,7 +18,7 @@ module.exports = {
     },
 
     run (expected) {
-        return exec("git branch | sed -n '/\\* /s///p'")
+        return exec("git branch --no-color | sed -n '/\\* /s///p'")
             .then(branch => {
                 if (branch !== expected)
                     throw 'Expected branch to be `' + expected + '`, but it was `' + branch + '`.';

--- a/test/test.js
+++ b/test/test.js
@@ -37,19 +37,39 @@ function getTestOptions (settings) {
     return defaults({}, settings && settings.set, disabled);
 }
 
+function colorGitOutput () {
+    const gitColorCommands = [
+        'git config color.branch.current blue',
+        'git config color.branch.local blue',
+        'git config color.branch.remote blue',
+        'git config color.diff.meta blue',
+        'git config color.diff.frag blue',
+        'git config color.diff.old blue',
+        'git config color.diff.new blue',
+        'git config color.status.added blue',
+        'git config color.status.changed blue',
+        'git config color.status.untracked blue'
+    ];
+
+    return Promise.all(gitColorCommands.map(s => exec(s)));
+}
+
 before(() => {
     require('../lib/publish').testMode     = true;
     require('../lib/validations').testMode = true;
 
     return del('testing-repo')
-        .then(() => exec('git clone https://github.com/inikulin/testing-repo.git'))
+        .then(() => exec('git clone https://github.com/inikulin/testing-repo.git testing-repo'))
         .then(() => process.chdir('testing-repo'));
 });
 
 after(() => {
     process.chdir('../');
-    return del('testing-repo');
+    return exec('sed -i\'\' \'/= blue/d\' .git/config')
+        .then(() => del('testing-repo'));
 });
+
+beforeEach(() => colorGitOutput());
 
 afterEach(() => exec('git reset --hard HEAD').then(exec('git clean -f -d')));
 


### PR DESCRIPTION
This patch explicitly tells `git branch` not to use colors. When git is configured to display the current branch with colors, publish-please fails:

`~/.gitconfig`:
```
[color "branch"]
  current = yellow reverse
```
Result:
![pp](https://cloud.githubusercontent.com/assets/2022803/15622166/c3cbb638-2466-11e6-9392-6949b9823f4a.jpg)

I didn't include a test case because I don't know how to test this.