### PR TITLE
Fix for branch validation on Windows

### DIFF
--- a/src/validations/branch.js
+++ b/src/validations/branch.js
@@ -18,8 +18,10 @@ module.exports = {
     },
 
     run (expected) {
-        return exec("git branch --no-color | sed -n '/\\* /s///p'")
+        return exec("git branch --no-color")
             .then(branch => {
+                branch = branch.match(/^\*\s(.*)$/gm)[0].replace("* ", "");
+                
                 if (branch !== expected)
                     throw 'Expected branch to be `' + expected + '`, but it was `' + branch + '`.';
             });


### PR DESCRIPTION
Since the `sed` command does not work on Windows it is better to use JavaScript to extract the current branch.