### PR TITLE
hotfix: against merge request #46:  it do not run postpublish script 

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -60,7 +60,10 @@ function publish (publishCommand, publishTag) {
 
     const spawnPromise = module.exports.testMode ?
         Promise.resolve() :
-        spawn(command).then(() => console.log('\n', emoji.tada, emoji.tada, emoji.tada));
+        spawn(command).then(res => {
+            console.log('\n', emoji.tada, emoji.tada, emoji.tada);
+            return res || true;
+        });
 
     return spawnPromise.then(() => command);
 }


### PR DESCRIPTION
# What happens
publish-please  do not run post-publish script anymore

# Why
previous merge Request #46 adds additional check for `if (!command ....) `:

    if (!command || !opts.postPublishScript)
                 return command;
 
             return runScript(opts.postPublishScript, SCRIPT_TYPE.postPublish)


where `command` is result of publish() promise. Which is `string` in test environment and `undefined` otherwise cuz it console log:

    if (!module.exports.testMode)
        return spawn(command).then(() => console.log('\n', emoji.tada, emoji.tada, emoji.tada));

Probably you need to review approach with 'testMode'  - cuz #46 passes all tests. 
