### PR TITLE
Add support for a custom publishing command, fix postpublish script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ npm run publish-please
 
  - **prePublishScript** - Specifies command that will be run before publish (e.g. `npm test`). Use it for builds and tests. Default: `npm test`.
  - **postPublishScript** - Specifies command that will be run after successful publishing. Use it for release announcements, creating a GitHub release, uploading binaries, etc. Default: `` (no command).
+ - **publishCommand** - Specifies publishing command which will be used to publish the package. Default: `npm publish`.
  - **publishTag** - Specifies tag with which package will be published. See [npm publish docs](https://docs.npmjs.com/cli/publish) for more info. Default: `latest`.
  - **confirm** - Ask for the confirmation before publishing. Default: `true`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,11 @@ const optionsConfigurators = {
         currentVal
     ),
 
+    publishCommand: currentVal => input(
+        'Specify publishing command which will be used to publish your package',
+        currentVal
+    ),
+
     publishTag: currentVal => input(
         'Specify release tag with which you package will be published',
         currentVal

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -2,6 +2,7 @@ module.exports = {
     validations: require('./validations').DEFAULT_OPTIONS,
 
     confirm:           true,
+    publishCommand:    'npm publish',
     publishTag:        'latest',
     prePublishScript:  'npm test',
     postPublishScript: ''

--- a/src/publish.js
+++ b/src/publish.js
@@ -54,13 +54,14 @@ function runScript (command, scriptType) {
         });
 }
 
-function publish (publishTag) {
-    const command = `npm publish --tag ${publishTag} --with-publish-please`;
+function publish (publishCommand, publishTag) {
+    const command = `${publishCommand} --tag ${publishTag} --with-publish-please`;
 
-    if (!module.exports.testMode)
-        return spawn(command).then(() => console.log('\n', emoji.tada, emoji.tada, emoji.tada));
+    const spawnPromise = module.exports.testMode ?
+        Promise.resolve() :
+        spawn(command).then(() => console.log('\n', emoji.tada, emoji.tada, emoji.tada));
 
-    return command;
+    return spawnPromise.then(() => command);
 }
 
 function getOptions (opts) {
@@ -114,7 +115,7 @@ module.exports = function (opts) {
         .then(() => validate(opts.validations, pkgInfo))
         .then(() => !module.exports.testMode && printReleaseInfo(pkgInfo.cfg.version, opts.publishTag))
         .then(() => opts.confirm ? confirm('Are you sure you want to publish this version to npm?', false) : true)
-        .then(ok => ok && publish(opts.publishTag) || '')
+        .then(ok => ok && publish(opts.publishCommand, opts.publishTag) || '')
         .then(command => {
             if (!command || !opts.postPublishScript)
                 return command;

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const readFile        = require('fs').readFileSync;
+const Promise         = require('pinkie-promise');
 const chalk           = require('chalk');
 const semver          = require('semver');
 const defaults        = require('lodash/defaultsDeep');

--- a/test/test.js
+++ b/test/test.js
@@ -118,6 +118,7 @@ describe('.publishrc', () => {
         assert(!opts.confirm);
         assert.strictEqual(opts.prePublishScript, 'npm test');
         assert.strictEqual(opts.postPublishScript, '');
+        assert.strictEqual(opts.publishCommand, 'npm publish');
         assert.strictEqual(opts.publishTag, 'latest');
         assert.strictEqual(opts.validations.branch, 'master');
         assert(!opts.validations.uncommittedChanges);
@@ -377,6 +378,18 @@ describe('Postpublish script', () => {
             .catch(err => assert.strictEqual(err.message, 'Command `git` exited with code 1.'))
             .catch(() => assert.throws(() => readFile('test-file'))));
 
+});
+
+describe('Custom publish command', () => {
+    it('Should execute a custom publish command if it is specified', () =>
+        exec('git checkout master')
+            .then(() => publish(getTestOptions({ set: { publishCommand: 'gulp publish' }, remove: 'publishTag' })))
+            .then(npmCmd => assert.strictEqual(npmCmd, 'gulp publish --tag latest --with-publish-please')));
+
+    it('Should execute a custom publish command with a custom tag', () =>
+            exec('git checkout master')
+                .then(() => publish(getTestOptions({ set: { publishCommand: 'gulp publish', publishTag: 'alpha' } })))
+                .then(npmCmd => assert.strictEqual(npmCmd, 'gulp publish --tag alpha --with-publish-please')));
 });
 
 describe('Publish tag', () => {


### PR DESCRIPTION
Custom publish command might be required, if you need to build a `.tgz` of a package first, change some attributes (e.g. file permissions), and publish modified `.tgz`.

\cc @inikulin 