### PR TITLE
Support exceptions from .nsprc file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2018-06-12
+### Fixed
+- Support vulnerability exceptions from .nsprc file
+
 ## [3.0.1] - 2018-06-05
 ### Fixed
 - installation on windows platform

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ npm run publish-please
  - **branch** - Check that current branch matches the specified branch. Default: `master`.
  - **sensitiveData** - Perform [audit for the sensitive data](#sensitive-information-audit). Default: `true`.
  - **vulnerableDependencies** - Perform vulnerable dependencies check using [Node Security Project](https://nodesecurity.io/) data. Default: `true`.
+    - you may prevent specific vulnerabilities to be reported by publish-please by creating a [.nsprc file](https://github.com/nodesecurity/nsp#exceptions).
+ 
 
 
 ## Sensitive information audit
@@ -127,7 +129,6 @@ Performed for the following items:
  - Rubygems credentials file
  - Potential MSBuild publish profile
  - PHP dotenv
-
 
 ## Check out my other packages used by this tool
 - [cp-sugar](https://github.com/inikulin/cp-sugar) - Some sugar for child_process module.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {

--- a/src/validations/vulnerable-dependencies.js
+++ b/src/validations/vulnerable-dependencies.js
@@ -31,7 +31,7 @@ module.exports = {
                 path: projectDir,
                 pkg: readPkg.sync(projectDir, { normalize: false }),
                 offline: false,
-                exceptions: [],
+                exceptions: defaultArgs.exceptions,
             };
 
             nsp

--- a/src/validations/vulnerable-dependencies.js
+++ b/src/validations/vulnerable-dependencies.js
@@ -31,7 +31,9 @@ module.exports = {
                 path: projectDir,
                 pkg: readPkg.sync(projectDir, { normalize: false }),
                 offline: false,
-                exceptions: defaultArgs.exceptions,
+                exceptions: Array.isArray(defaultArgs.exceptions)
+                    ? defaultArgs.exceptions
+                    : [],
             };
 
             nsp

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --reporter spec
 --ui tdd
---timeout 50000
+--timeout 90000

--- a/test/test.js
+++ b/test/test.js
@@ -523,14 +523,21 @@ describe('Integration tests', () => {
                     }));
         });
 
-	it('Should respect exceptions configured in .npmrc file', () =>
+        it('Should respect exceptions configured in .npmrc file', () =>
             exec('git checkout master')
                 .then(() => pkgd())
                 .then((pkgInfo) => {
                     pkgInfo.cfg.dependencies = {};
                     pkgInfo.cfg.dependencies['lodash'] = '4.16.4';
                     writeFile('package.json', JSON.stringify(pkgInfo.cfg));
-                    writeFile('.nsprc', JSON.stringify({exceptions:['https://nodesecurity.io/advisories/577']}));
+                    writeFile(
+                        '.nsprc',
+                        JSON.stringify({
+                            exceptions: [
+                                'https://nodesecurity.io/advisories/577',
+                            ],
+                        })
+                    );
                 })
                 .then(() =>
                     publish(
@@ -542,8 +549,7 @@ describe('Integration tests', () => {
                             },
                         })
                     )
-                )
-        );
+                ));
 
         ['lodash@4.17.5', 'ms@0.7.1'].forEach(function(dependency) {
             const name = dependency.split('@')[0];

--- a/test/test.js
+++ b/test/test.js
@@ -523,6 +523,28 @@ describe('Integration tests', () => {
                     }));
         });
 
+	it('Should respect exceptions configured in .npmrc file', () =>
+            exec('git checkout master')
+                .then(() => pkgd())
+                .then((pkgInfo) => {
+                    pkgInfo.cfg.dependencies = {};
+                    pkgInfo.cfg.dependencies['lodash'] = '4.16.4';
+                    writeFile('package.json', JSON.stringify(pkgInfo.cfg));
+                    writeFile('.nsprc', JSON.stringify({exceptions:['https://nodesecurity.io/advisories/577']}));
+                })
+                .then(() =>
+                    publish(
+                        getTestOptions({
+                            set: {
+                                validations: {
+                                    vulnerableDependencies: true,
+                                },
+                            },
+                        })
+                    )
+                )
+        );
+
         ['lodash@4.17.5', 'ms@0.7.1'].forEach(function(dependency) {
             const name = dependency.split('@')[0];
             const version = dependency.split('@')[1];

--- a/test/utils/publish-please-version-under-test.js
+++ b/test/utils/publish-please-version-under-test.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = 'publish-please@3.0.1';
+module.exports = 'publish-please@3.0.2';


### PR DESCRIPTION
This behavior was previously supported, but recent updates seem to have broken it.

Allows user to define which security warnings are to be ignored by entering them in the `.nsprc` file 