### PR TITLE
[WIP] gracefully handle prepublish vs prepublishOnly script on all node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
**As of npm@5, `prepublish` scripts are deprecated**

this means that:
* if node 6 and npm < 5 : use `prepublish` script hook in `package.json`
* if node 6 and npm >= 5: use `prepublishOnly` script hook in `package.json` on new install but keep `prepublish` script if already there in the `package.json`
* if node  >= 8  same strategy as above and show a warning message on `npm install publish-please` if there is an existing `prepublish` script inside the package.json