### PR TITLE
Be able to run publish-please with npx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ node_js:
   - '10'
 
 before_install:
+  - if [[ `node -v` = v6* ]]; then npm i -g npx; fi
   - npx --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ node_js:
   - '8'
   - '9'
   - '10'
-  
+
+before_install:
+  - npx --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] - 2018-07-15
-### Unreleased
+## [3.2.0] - 2018-07-12
+### Added
 - be able to run publish-please with npx
 
 ## [3.1.1] - 2018-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2018-07-15
+### Unreleased
+- be able to run publish-please with npx
+
 ## [3.1.1] - 2018-07-01
 ### Fixed
 - gracefully handle prepublish vs prepublishOnly script on all node versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] - 2018-07-12
+## [3.2.0] - 2018-07-15
 ### Added
 - be able to run publish-please with npx
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ There are numerous ways to "shoot yourself in the foot" using `npm publish`. The
  - Get release summary and publishing confirmation.
  - Configure publishing using built-in configuration wizard.
 
-## Getting started
+## Getting started ( [or use npx directly](#Running-publish-please-with-npx) )
+
 Setup process of *publish-please* is quite trivial - just run
 ```shell
 npm install --save-dev publish-please
@@ -90,6 +91,24 @@ It might be a good idea to add these two lines inside your .gitignore file:
 ```sh
 package
 *.tgz
+```
+
+## Running publish-please with npx
+
+You can execute publish-please directly with npx:  
+* **Publish in a dry-run mode**
+```sh
+npx publish-please --dry-run
+```
+
+* **Safely publish to the npm registry**
+```sh
+npx publish-please
+```
+
+* **Setup a configuration file in order to customise the publishing workflow**
+```sh
+npx publish-please config
 ```
 
 ## Sensitive information audit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,6 @@ test_script:
   - node --version
   - npm --version
   - npx --version
-  - npm run build
-  - npm run package
-  - npx ./publish-please-3.2.0.tgz
   - npm test
 cache:
   - '%APPDATA%\npm-cache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - set PATH=%APPDATA%\npm;%PATH%
   - ps: >-
-      if ($env.nodejs_version -eq "6") {
+      if ($env:nodejs_version -eq "6") {
         npm i -g npx
       }
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - set PATH=%APPDATA%\npm;%PATH%
+  - ps: >-
+      if ($env.nodejs_version -eq "6") {
+        npm i -g npx
+      }
   - npm install
 matrix:
   fast_finish: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ shallow_clone: true
 test_script:
   - node --version
   - npm --version
+  - npx --version
   - npm test
 cache:
   - '%APPDATA%\npm-cache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ test_script:
   - node --version
   - npm --version
   - npx --version
+  - npm run build
+  - npm run package
+  - npx ./publish-please-3.2.0.tgz
   - npm test
 cache:
   - '%APPDATA%\npm-cache'

--- a/lib/post-install.js
+++ b/lib/post-install.js
@@ -2,8 +2,13 @@
 
 const fileExists = require('fs').existsSync;
 const pathJoin = require('path').join;
+const getNpmArgs = require('./utils/get-npm-args');
+const npmArgs = getNpmArgs(process.env);
 
 (function postInstall(currentDir) {
+    if (npmArgs.npx) {
+        return;
+    }
     const jsFile = pathJoin(currentDir || __dirname, 'init.js');
     if (fileExists(jsFile)) {
         const initConfiguration = require(jsFile);

--- a/lib/post-install.js
+++ b/lib/post-install.js
@@ -3,12 +3,21 @@
 const fileExists = require('fs').existsSync;
 const pathJoin = require('path').join;
 
+function isNpxInstall() {
+    try {
+        const getNpmArgs = require('./utils/get-npm-args');
+        const npmArgs = getNpmArgs(process.env);
+        return npmArgs.npx ? true : false;
+    } catch (error) {
+        return false;
+    }
+}
+
 (function postInstall(currentDir) {
-    const getNpmArgs = require('./utils/get-npm-args');
-    const npmArgs = getNpmArgs(process.env);
-    if (npmArgs.npx) {
+    if (isNpxInstall()) {
         return;
     }
+
     const jsFile = pathJoin(currentDir || __dirname, 'init.js');
     if (fileExists(jsFile)) {
         const initConfiguration = require(jsFile);

--- a/lib/post-install.js
+++ b/lib/post-install.js
@@ -2,10 +2,10 @@
 
 const fileExists = require('fs').existsSync;
 const pathJoin = require('path').join;
-const getNpmArgs = require('./utils/get-npm-args');
-const npmArgs = getNpmArgs(process.env);
 
 (function postInstall(currentDir) {
+    const getNpmArgs = require('./utils/get-npm-args');
+    const npmArgs = getNpmArgs(process.env);
     if (npmArgs.npx) {
         return;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,43 @@
 'use strict';
 
 const getNpmArgs = require('./utils/get-npm-args');
+const getNpxArgs = require('./utils/get-npx-args');
 
 module.exports = function() {
     if (process.argv.indexOf('guard') > -1) {
         return require('./guard')(process.env);
     }
-    const npmArgs = getNpmArgs(process.env);
-    if (npmArgs && npmArgs['config']) {
+
+    if (shouldRunConfigurationWizard()) {
         const config = require('./config');
         return config.configurePublishPlease.inCurrentProject();
     }
 
-    if (npmArgs && npmArgs['--dry-run']) {
+    if (shouldRunInDryMode()) {
         return require('./publish/dry-run-workflow')();
     }
 
     return require('./publish/publish-workflow')();
 };
+
+function shouldRunInDryMode() {
+    const npmArgs = getNpmArgs(process.env);
+    if (npmArgs && npmArgs['--dry-run']) {
+        return true;
+    }
+
+    const npxArgs = getNpxArgs(process);
+    if (npxArgs && npxArgs['--dry-run']) {
+        return true;
+    }
+
+    return false;
+}
+
+function shouldRunConfigurationWizard() {
+    const npmArgs = getNpmArgs(process.env);
+    if (npmArgs && npmArgs['config']) {
+        return true;
+    }
+    return false;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -39,5 +39,10 @@ function shouldRunConfigurationWizard() {
     if (npmArgs && npmArgs['config']) {
         return true;
     }
+
+    const npxArgs = getNpxArgs(process);
+    if (npxArgs && npxArgs['config']) {
+        return true;
+    }
     return false;
 }

--- a/src/post-install.js
+++ b/src/post-install.js
@@ -2,8 +2,13 @@
 
 const fileExists = require('fs').existsSync;
 const pathJoin = require('path').join;
+const getNpmArgs = require('./utils/get-npm-args');
+const npmArgs = getNpmArgs(process.env);
 
 (function postInstall(currentDir) {
+    if (npmArgs.npx) {
+        return;
+    }
     const jsFile = pathJoin(currentDir || __dirname, 'init.js');
     if (fileExists(jsFile)) {
         const initConfiguration = require(jsFile);

--- a/src/post-install.js
+++ b/src/post-install.js
@@ -3,12 +3,21 @@
 const fileExists = require('fs').existsSync;
 const pathJoin = require('path').join;
 
+function isNpxInstall() {
+    try {
+        const getNpmArgs = require('./utils/get-npm-args');
+        const npmArgs = getNpmArgs(process.env);
+        return npmArgs.npx ? true : false;
+    } catch (error) {
+        return false;
+    }
+}
+
 (function postInstall(currentDir) {
-    const getNpmArgs = require('./utils/get-npm-args');
-    const npmArgs = getNpmArgs(process.env);
-    if (npmArgs.npx) {
+    if (isNpxInstall()) {
         return;
     }
+
     const jsFile = pathJoin(currentDir || __dirname, 'init.js');
     if (fileExists(jsFile)) {
         const initConfiguration = require(jsFile);

--- a/src/post-install.js
+++ b/src/post-install.js
@@ -2,10 +2,10 @@
 
 const fileExists = require('fs').existsSync;
 const pathJoin = require('path').join;
-const getNpmArgs = require('./utils/get-npm-args');
-const npmArgs = getNpmArgs(process.env);
 
 (function postInstall(currentDir) {
+    const getNpmArgs = require('./utils/get-npm-args');
+    const npmArgs = getNpmArgs(process.env);
     if (npmArgs.npx) {
         return;
     }

--- a/src/prevent-global-install.js
+++ b/src/prevent-global-install.js
@@ -11,6 +11,9 @@ const NO_GLOBAL_INSTALL_MESSAGE = `
 module.exports = function preventGlobalInstall() {
     const getNpmArgs = require('./utils/get-npm-args');
     const npmArgs = getNpmArgs(process.env);
+    if (npmArgs.npx) {
+        return;
+    }
     if (npmArgs['--global']) {
         reportNoGlobalInstall();
         process.exit(1);

--- a/src/utils/fluent-syntax.js
+++ b/src/utils/fluent-syntax.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports.arg = function(input) {
+    return {
+        is: (predicate) => {
+            return predicate(input);
+        },
+    };
+};
+
+module.exports.npmCommand = function(args) {
+    const isValidArgs = args && args.cooked && Array.isArray(args.cooked);
+    return {
+        hasArg: (arg) => {
+            return isValidArgs
+                ? args.cooked.filter((a) => a === arg).length > 0
+                : false;
+        },
+        hasArgThatContains: (substring) => {
+            /* prettier-ignore */
+            return isValidArgs
+                ? args.cooked.filter((a) => a && a.includes(substring)).length > 0
+                : false;
+        },
+    };
+};

--- a/src/utils/get-npm-args.js
+++ b/src/utils/get-npm-args.js
@@ -1,14 +1,11 @@
 'use strict';
-const pathJoin = require('path').join;
+const pathSeparator = require('path').sep;
 
 // NOTE: the following code was partially adopted from https://github.com/iarna/in-publish
 module.exports = function getNpmArgs(processEnv) {
     const npmArgs = {};
     if (processEnv && processEnv['npm_config_argv']) {
         try {
-            console.error(processEnv['npm_config_argv']);
-            console.error('===========================');
-            console.error(process.env);
             const args = JSON.parse(processEnv['npm_config_argv']);
             npmArgs.install =
                 npmCommand(args).hasArg('install') ||
@@ -22,18 +19,20 @@ module.exports = function getNpmArgs(processEnv) {
             npmArgs['config'] = npmCommand(args).hasArg('config');
             npmArgs.npx =
                 npmCommand(args).hasArg('--prefix') &&
-                npmCommand(args).hasArgThatContains(pathJoin('.npm', '_npx'));
+                npmCommand(args).hasArgThatContains(
+                    `${pathSeparator}_npx${pathSeparator}`
+                );
             // prettier-ignore
             npmArgs['--with-publish-please'] = npmCommand(args).hasArg('--with-publish-please');
         } catch (err) {
-            console.error(err.message);
-            console.warn(
+            console.error(
                 "[Publish-please] Cannot parse property 'npm_config_argv' in process.env "
             );
             // prettier-ignore
-            console.warn(
+            console.error(
                 `[Publish-please] process.env['npm_config_argv']= '${processEnv['npm_config_argv']}'`
             );
+            console.error(`[Publish-please] ${err.message}`);
         }
     }
 

--- a/src/utils/get-npm-args.js
+++ b/src/utils/get-npm-args.js
@@ -1,57 +1,58 @@
 'use strict';
 const pathSeparator = require('path').sep;
+const npmCommand = require('./fluent-syntax').npmCommand;
+const arg = require('./fluent-syntax').arg;
 
 // NOTE: the following code was partially adopted from https://github.com/iarna/in-publish
 module.exports = function getNpmArgs(processEnv) {
+    if (arg(processEnv).is(notValid)) {
+        return {};
+    }
     const npmArgs = {};
-    if (processEnv && processEnv['npm_config_argv']) {
-        try {
-            const args = JSON.parse(processEnv['npm_config_argv']);
-            npmArgs.install =
-                npmCommand(args).hasArg('install') ||
-                npmCommand(args).hasArg('i');
-            npmArgs.publish = npmCommand(args).hasArg('publish');
-            npmArgs.runScript = npmCommand(args).hasArg('run');
-            npmArgs['--save-dev'] = npmCommand(args).hasArg('--save-dev');
-            npmArgs['--save'] = npmCommand(args).hasArg('--save');
-            npmArgs['--global'] = npmCommand(args).hasArg('--global');
-            npmArgs['--dry-run'] = npmCommand(args).hasArg('--dry-run');
-            npmArgs['config'] = npmCommand(args).hasArg('config');
-            npmArgs.npx =
-                npmCommand(args).hasArg('--prefix') &&
-                npmCommand(args).hasArgThatContains(
-                    `${pathSeparator}_npx${pathSeparator}`
-                );
-            // prettier-ignore
-            npmArgs['--with-publish-please'] = npmCommand(args).hasArg('--with-publish-please');
-        } catch (err) {
-            console.error(
-                "[Publish-please] Cannot parse property 'npm_config_argv' in process.env "
+    try {
+        const args = JSON.parse(processEnv['npm_config_argv']);
+        npmArgs.install =
+            npmCommand(args).hasArg('install') || npmCommand(args).hasArg('i');
+        npmArgs.publish = npmCommand(args).hasArg('publish');
+        npmArgs.runScript = npmCommand(args).hasArg('run');
+        npmArgs['--save-dev'] = npmCommand(args).hasArg('--save-dev');
+        npmArgs['--save'] = npmCommand(args).hasArg('--save');
+        npmArgs['--global'] = npmCommand(args).hasArg('--global');
+        npmArgs['--dry-run'] = npmCommand(args).hasArg('--dry-run');
+        npmArgs['config'] = npmCommand(args).hasArg('config');
+        npmArgs.npx =
+            npmCommand(args).hasArg('--prefix') &&
+            npmCommand(args).hasArgThatContains(
+                `${pathSeparator}_npx${pathSeparator}`
             );
-            // prettier-ignore
-            console.error(
-                `[Publish-please] process.env['npm_config_argv']= '${processEnv['npm_config_argv']}'`
-            );
-            console.error(`[Publish-please] ${err.message}`);
-        }
+        // prettier-ignore
+        npmArgs['--with-publish-please'] = npmCommand(args).hasArg('--with-publish-please');
+    } catch (err) {
+        console.error(
+            "[Publish-please] Cannot parse property 'npm_config_argv' in process.env "
+        );
+        // prettier-ignore
+        console.error(
+            `[Publish-please] process.env['npm_config_argv']= '${processEnv['npm_config_argv']}'`
+        );
+        console.error(`[Publish-please] ${err.message}`);
     }
 
     return npmArgs;
 };
 
-function npmCommand(args) {
-    const isValidArgs = args && args.cooked && Array.isArray(args.cooked);
-    return {
-        hasArg: (arg) => {
-            return isValidArgs
-                ? args.cooked.filter((a) => a === arg).length > 0
-                : false;
-        },
-        hasArgThatContains: (substring) => {
-            /* prettier-ignore */
-            return isValidArgs
-                ? args.cooked.filter((a) => a && a.includes(substring)).length > 0
-                : false;
-        },
-    };
+function notValid(processEnv) {
+    if (processEnv === null || processEnv === undefined) {
+        return true;
+    }
+
+    if (processEnv['npm_config_argv'] === undefined) {
+        return true;
+    }
+
+    if (processEnv['npm_config_argv'] === 'undefined') {
+        return true;
+    }
+
+    return false;
 }

--- a/src/utils/get-npm-args.js
+++ b/src/utils/get-npm-args.js
@@ -7,6 +7,8 @@ module.exports = function getNpmArgs(processEnv) {
     if (processEnv && processEnv['npm_config_argv']) {
         try {
             console.error(processEnv['npm_config_argv']);
+            console.error('===========================');
+            console.error(process.env);
             const args = JSON.parse(processEnv['npm_config_argv']);
             npmArgs.install =
                 npmCommand(args).hasArg('install') ||

--- a/src/utils/get-npm-args.js
+++ b/src/utils/get-npm-args.js
@@ -24,6 +24,7 @@ module.exports = function getNpmArgs(processEnv) {
             // prettier-ignore
             npmArgs['--with-publish-please'] = npmCommand(args).hasArg('--with-publish-please');
         } catch (err) {
+            console.error(err.message);
             console.warn(
                 "[Publish-please] Cannot parse property 'npm_config_argv' in process.env "
             );

--- a/src/utils/get-npm-args.js
+++ b/src/utils/get-npm-args.js
@@ -1,10 +1,12 @@
 'use strict';
+const pathJoin = require('path').join;
 
 // NOTE: the following code was partially adopted from https://github.com/iarna/in-publish
 module.exports = function getNpmArgs(processEnv) {
     const npmArgs = {};
     if (processEnv && processEnv['npm_config_argv']) {
         try {
+            console.error(processEnv['npm_config_argv']);
             const args = JSON.parse(processEnv['npm_config_argv']);
             npmArgs.install =
                 npmCommand(args).hasArg('install') ||
@@ -16,6 +18,9 @@ module.exports = function getNpmArgs(processEnv) {
             npmArgs['--global'] = npmCommand(args).hasArg('--global');
             npmArgs['--dry-run'] = npmCommand(args).hasArg('--dry-run');
             npmArgs['config'] = npmCommand(args).hasArg('config');
+            npmArgs.npx =
+                npmCommand(args).hasArg('--prefix') &&
+                npmCommand(args).hasArgThatContains(pathJoin('.npm', '_npx'));
             // prettier-ignore
             npmArgs['--with-publish-please'] = npmCommand(args).hasArg('--with-publish-please');
         } catch (err) {
@@ -38,6 +43,12 @@ function npmCommand(args) {
         hasArg: (arg) => {
             return isValidArgs
                 ? args.cooked.filter((a) => a === arg).length > 0
+                : false;
+        },
+        hasArgThatContains: (substring) => {
+            /* prettier-ignore */
+            return isValidArgs
+                ? args.cooked.filter((a) => a && a.includes(substring)).length > 0
                 : false;
         },
     };

--- a/src/utils/get-npx-args.js
+++ b/src/utils/get-npx-args.js
@@ -11,6 +11,11 @@ module.exports = function getNpxArgs(process) {
         npxCommand(args).hasArgThatContains(
             `${pathSeparator}_npx${pathSeparator}`
         );
+    npxArgs['config'] =
+        npxCommand(args).hasArg('config') &&
+        npxCommand(args).hasArgThatContains(
+            `${pathSeparator}_npx${pathSeparator}`
+        );
     return npxArgs;
 };
 

--- a/src/utils/get-npx-args.js
+++ b/src/utils/get-npx-args.js
@@ -1,0 +1,32 @@
+'use strict';
+const pathSeparator = require('path').sep;
+
+module.exports = function getNpxArgs(process) {
+    const npxArgs = {};
+
+    const args = process && process.argv ? process.argv : [];
+
+    npxArgs['--dry-run'] =
+        npxCommand(args).hasArg('--dry-run') &&
+        npxCommand(args).hasArgThatContains(
+            `${pathSeparator}_npx${pathSeparator}`
+        );
+    return npxArgs;
+};
+
+function npxCommand(args) {
+    const isValidArgs = args && Array.isArray(args);
+    return {
+        hasArg: (arg) => {
+            return isValidArgs
+                ? args.filter((a) => a === arg).length > 0
+                : false;
+        },
+        hasArgThatContains: (substring) => {
+            /* prettier-ignore */
+            return isValidArgs ?
+                args.filter((a) => a && a.includes(substring)).length > 0 :
+                false;
+        },
+    };
+}

--- a/test/get-npm-args.spec.js
+++ b/test/get-npm-args.spec.js
@@ -4,6 +4,7 @@ const npmArgs = require('../lib/utils/get-npm-args');
 /* eslint-disable no-unused-vars */
 const should = require('should');
 const packageName = require('./utils/publish-please-version-under-test');
+const pathJoin = require('path').join;
 
 describe('npm args parser util', () => {
     it('Should return an empty object when process.env does not exist', () => {
@@ -216,8 +217,10 @@ describe('npm args parser util', () => {
 
     it("Should parse the command 'npx publish-please'", () => {
         // Given
-        process.env['npm_config_argv'] =
-            '{"remain":["publish-please"],"cooked":["install","publish-please","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"],"original":["install","publish-please","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"]}';
+        const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
+        process.env[
+            'npm_config_argv'
+        ] = `{"remain":["publish-please"],"cooked":["install","publish-please","--global","--prefix","${npxPath}","--loglevel","error","--json"],"original":["install","publish-please","--global","--prefix","${npxPath}","--loglevel","error","--json"]}`;
         // When
         const args = npmArgs(process.env);
         // Then

--- a/test/get-npm-args.spec.js
+++ b/test/get-npm-args.spec.js
@@ -7,7 +7,7 @@ const packageName = require('./utils/publish-please-version-under-test');
 const pathJoin = require('path').join;
 
 describe('npm args parser util', () => {
-    it('Should return an empty object when process.env does not exist', () => {
+    it('Should return an empty object when process.env is undefined', () => {
         // Given
         const processEnv = undefined;
         // When
@@ -18,6 +18,23 @@ describe('npm args parser util', () => {
     it('Should return an empty object when the command is not an npm command', () => {
         // Given
         process.env['npm_config_argv'] = undefined;
+        const processEnv = process.env;
+        // When
+        const args = npmArgs(processEnv);
+        // Then
+        args.should.be.empty();
+    });
+    it('Should return an empty object when process.env["npm_config_argv"] does not exist', () => {
+        // Given
+        delete process.env['npm_config_argv'];
+        // When
+        const args = npmArgs(process.env);
+        // Then
+        args.should.be.empty();
+    });
+    it('Should return an empty object when process.env["npm_config_argv"] is a bad json', () => {
+        // Given
+        process.env['npm_config_argv'] = '<bad json>';
         const processEnv = process.env;
         // When
         const args = npmArgs(processEnv);

--- a/test/get-npm-args.spec.js
+++ b/test/get-npm-args.spec.js
@@ -215,7 +215,7 @@ describe('npm args parser util', () => {
         args['config'].should.be.true();
     });
 
-    it("Should parse the command 'npx publish-please'", () => {
+    it.only("Should parse the command 'npx publish-please'", () => {
         // Given
         const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
         process.env[

--- a/test/get-npm-args.spec.js
+++ b/test/get-npm-args.spec.js
@@ -217,10 +217,12 @@ describe('npm args parser util', () => {
 
     it.only("Should parse the command 'npx publish-please'", () => {
         // Given
-        const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
+        const npxPath = JSON.stringify(
+            pathJoin('Users', 'HDO', '.npm', '_npx', '78031')
+        );
         process.env[
             'npm_config_argv'
-        ] = `{"remain":["publish-please"],"cooked":["install","publish-please","--global","--prefix","${npxPath}","--loglevel","error","--json"],"original":["install","publish-please","--global","--prefix","${npxPath}","--loglevel","error","--json"]}`;
+        ] = `{"remain":["publish-please"],"cooked":["install","publish-please","--global","--prefix",${npxPath},"--loglevel","error","--json"],"original":["install","publish-please","--global","--prefix",${npxPath},"--loglevel","error","--json"]}`;
         // When
         const args = npmArgs(process.env);
         // Then

--- a/test/get-npm-args.spec.js
+++ b/test/get-npm-args.spec.js
@@ -33,6 +33,7 @@ describe('npm args parser util', () => {
         args.publish.should.be.true();
         args.install.should.be.false();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--with-publish-please'].should.be.false();
         args['--dry-run'].should.be.false();
         args['config'].should.be.false();
@@ -47,6 +48,7 @@ describe('npm args parser util', () => {
         args.publish.should.be.true();
         args.install.should.be.false();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--with-publish-please'].should.be.true();
         args['--dry-run'].should.be.false();
         args['config'].should.be.false();
@@ -61,6 +63,7 @@ describe('npm args parser util', () => {
         args.publish.should.be.false();
         args.install.should.be.false();
         args.runScript.should.be.true();
+        args.npx.should.be.false();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
         args['--global'].should.be.false();
@@ -78,6 +81,7 @@ describe('npm args parser util', () => {
         args.publish.should.be.false();
         args.install.should.be.true();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
         args['--global'].should.be.false();
@@ -95,6 +99,7 @@ describe('npm args parser util', () => {
         args.publish.should.be.false();
         args.install.should.be.true();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
         args['--global'].should.be.false();
@@ -113,6 +118,7 @@ describe('npm args parser util', () => {
         args.install.should.be.true();
         args.publish.should.be.false();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--save-dev'].should.be.true();
         args['--save'].should.be.false();
         args['--global'].should.be.false();
@@ -130,6 +136,7 @@ describe('npm args parser util', () => {
         args.install.should.be.true();
         args.publish.should.be.false();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--save-dev'].should.be.true();
         args['--save'].should.be.false();
         args['--global'].should.be.false();
@@ -147,6 +154,7 @@ describe('npm args parser util', () => {
         args.install.should.be.true();
         args.publish.should.be.false();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--global'].should.be.true();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
@@ -164,6 +172,7 @@ describe('npm args parser util', () => {
         args.install.should.be.true();
         args.publish.should.be.false();
         args.runScript.should.be.false();
+        args.npx.should.be.false();
         args['--global'].should.be.true();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
@@ -180,6 +189,7 @@ describe('npm args parser util', () => {
         args.install.should.be.false();
         args.publish.should.be.false();
         args.runScript.should.be.true();
+        args.npx.should.be.false();
         args['--global'].should.be.false();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
@@ -196,10 +206,29 @@ describe('npm args parser util', () => {
         args.install.should.be.false();
         args.publish.should.be.false();
         args.runScript.should.be.true();
+        args.npx.should.be.false();
         args['--global'].should.be.false();
         args['--save-dev'].should.be.false();
         args['--save'].should.be.false();
         args['--dry-run'].should.be.false();
         args['config'].should.be.true();
+    });
+
+    it("Should parse the command 'npx publish-please'", () => {
+        // Given
+        process.env['npm_config_argv'] =
+            '{"remain":["publish-please"],"cooked":["install","publish-please","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"],"original":["install","publish-please","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"]}';
+        // When
+        const args = npmArgs(process.env);
+        // Then
+        args.install.should.be.true();
+        args.publish.should.be.false();
+        args.runScript.should.be.false();
+        args.npx.should.be.true();
+        args['--global'].should.be.true();
+        args['--save-dev'].should.be.false();
+        args['--save'].should.be.false();
+        args['--dry-run'].should.be.false();
+        args['config'].should.be.false();
     });
 });

--- a/test/get-npm-args.spec.js
+++ b/test/get-npm-args.spec.js
@@ -215,7 +215,7 @@ describe('npm args parser util', () => {
         args['config'].should.be.true();
     });
 
-    it.only("Should parse the command 'npx publish-please'", () => {
+    it("Should parse the command 'npx publish-please'", () => {
         // Given
         const npxPath = JSON.stringify(
             pathJoin('Users', 'HDO', '.npm', '_npx', '78031')

--- a/test/get-npx-args.spec.js
+++ b/test/get-npx-args.spec.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const npxArgs = require('../lib/utils/get-npx-args');
+/* eslint-disable no-unused-vars */
+const should = require('should');
+const pathJoin = require('path').join;
+
+describe('npx args parser util', () => {
+    before(() => {
+        process.env['npm_config_argv'] = undefined;
+    });
+    it('Should parse even if process does not exist', () => {
+        // Given
+        const process = undefined;
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.false();
+    });
+    it('Should parse even if process.argv does not exist', () => {
+        // Given
+        const process = {};
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.false();
+    });
+    it('Should parse even if process.argv is not an array', () => {
+        // Given
+        const process = {};
+        process.argv = {};
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.false();
+    });
+    it('Should parse even if process.argv is an empty array', () => {
+        // Given
+        const process = {};
+        process.argv = [];
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.false();
+    });
+    it('Should parse even if the command is not an npx command', () => {
+        // Given
+        process.argv = ['/usr/local/bin/node', 'publish-please', '--dry-run'];
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.false();
+    });
+    it('Should parse the command `npx publish-please --dry-run`', () => {
+        // Given
+        // [ '/usr/local/bin/node',
+        //   '/Users/HDO/.npm/_npx/97852/bin/publish-please',
+        //   '--dry-run'
+        // ]
+
+        process.argv = [
+            pathJoin('usr', 'local', 'bin', 'node'),
+            pathJoin(
+                'Users',
+                'xxx',
+                '.npm',
+                '_npx',
+                '97852',
+                'bin',
+                'publish-please'
+            ),
+            '--dry-run',
+        ];
+
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.true();
+    });
+});

--- a/test/get-npx-args.spec.js
+++ b/test/get-npx-args.spec.js
@@ -16,6 +16,7 @@ describe('npx args parser util', () => {
         const args = npxArgs(process);
         // Then
         args['--dry-run'].should.be.false();
+        args['config'].should.be.false();
     });
     it('Should parse even if process.argv does not exist', () => {
         // Given
@@ -24,6 +25,7 @@ describe('npx args parser util', () => {
         const args = npxArgs(process);
         // Then
         args['--dry-run'].should.be.false();
+        args['config'].should.be.false();
     });
     it('Should parse even if process.argv is not an array', () => {
         // Given
@@ -33,6 +35,7 @@ describe('npx args parser util', () => {
         const args = npxArgs(process);
         // Then
         args['--dry-run'].should.be.false();
+        args['config'].should.be.false();
     });
     it('Should parse even if process.argv is an empty array', () => {
         // Given
@@ -42,6 +45,7 @@ describe('npx args parser util', () => {
         const args = npxArgs(process);
         // Then
         args['--dry-run'].should.be.false();
+        args['config'].should.be.false();
     });
     it('Should parse even if the command is not an npx command', () => {
         // Given
@@ -50,6 +54,7 @@ describe('npx args parser util', () => {
         const args = npxArgs(process);
         // Then
         args['--dry-run'].should.be.false();
+        args['config'].should.be.false();
     });
     it('Should parse the command `npx publish-please --dry-run`', () => {
         // Given
@@ -76,5 +81,34 @@ describe('npx args parser util', () => {
         const args = npxArgs(process);
         // Then
         args['--dry-run'].should.be.true();
+        args['config'].should.be.false();
+    });
+
+    it('Should parse the command `npx publish-please config`', () => {
+        // Given
+        // [ '/usr/local/bin/node',
+        //   '/Users/HDO/.npm/_npx/97852/bin/publish-please',
+        //   'config'
+        // ]
+
+        process.argv = [
+            pathJoin('usr', 'local', 'bin', 'node'),
+            pathJoin(
+                'Users',
+                'xxx',
+                '.npm',
+                '_npx',
+                '97852',
+                'bin',
+                'publish-please'
+            ),
+            'config',
+        ];
+
+        // When
+        const args = npxArgs(process);
+        // Then
+        args['--dry-run'].should.be.false();
+        args['config'].should.be.true();
     });
 });

--- a/test/get-npx-args.spec.js
+++ b/test/get-npx-args.spec.js
@@ -6,8 +6,13 @@ const should = require('should');
 const pathJoin = require('path').join;
 
 describe('npx args parser util', () => {
+    let originalArgv;
     before(() => {
         process.env['npm_config_argv'] = undefined;
+        originalArgv = process.argv.map((arg) => arg);
+    });
+    after(() => {
+        process.argv = originalArgv;
     });
     it('Should parse even if process does not exist', () => {
         // Given

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -87,6 +87,53 @@ describe('Publish-please CLI Options', () => {
         );
     });
 
+    it('Should execute configuration workflow on `npx publish-please config`', () => {
+        // Given
+        process.env['npm_config_argv'] = undefined;
+
+        // [ '/usr/local/bin/node',
+        //   '/Users/HDO/.npm/_npx/97852/bin/publish-please',
+        //   'config'
+        // ]
+        process.argv = [
+            pathJoin('usr', 'local', 'bin', 'node'),
+            pathJoin(
+                'Users',
+                'xxx',
+                '.npm',
+                '_npx',
+                '97852',
+                'bin',
+                'publish-please'
+            ),
+            'config',
+        ];
+        // When
+        return cli().then(() => {
+            output.should.containEql('Configuring option "prePublishScript":');
+            output.should.containEql('Configuring option "postPublishScript":');
+            output.should.containEql('Configuring option "publishCommand":');
+            output.should.containEql('Configuring option "publishTag"');
+            output.should.containEql('Configuring option "confirm":');
+            output.should.containEql(
+                'Configuring validation "vulnerableDependencies"'
+            );
+            output.should.containEql(
+                'Configuring validation "uncommittedChanges":'
+            );
+            output.should.containEql(
+                'Configuring validation "untrackedFiles":'
+            );
+            output.should.containEql('Configuring validation "sensitiveData":');
+            output.should.containEql('Configuring validation "branch":');
+            output.should.containEql('Configuring validation "gitTag"');
+            output.should.containEql('Current configuration:');
+            output.should.containEql(
+                'Configuration has been successfully saved.'
+            );
+        });
+    });
+
     it('Should execute guard on `publish-please guard`', () => {
         // Given
         process.env['npm_config_argv'] =

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -82,6 +82,7 @@ describe('Publish-please CLI Options', () => {
         const publishrc = JSON.parse(readFile('.publishrc').toString());
         publishrc.confirm = false;
         publishrc.validations.uncommittedChanges = false;
+        publishrc.validations.untrackedFiles = false;
         publishrc.validations.gitTag = false;
         publishrc.validations.branch = false;
         writeFile('.publishrc', JSON.stringify(publishrc, null, 2));
@@ -159,6 +160,7 @@ describe('Publish-please CLI Options', () => {
         const publishrc = JSON.parse(readFile('.publishrc').toString());
         publishrc.confirm = false;
         publishrc.validations.uncommittedChanges = false;
+        publishrc.validations.untrackedFiles = false;
         publishrc.validations.gitTag = false;
         publishrc.validations.branch = false;
         writeFile('.publishrc', JSON.stringify(publishrc, null, 2));

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,7 @@
 const readFile = require('fs').readFileSync;
 const should = require('should');
 const cli = require('../lib');
+const pathJoin = require('path').join;
 
 describe('Publish-please CLI Options', () => {
     let nativeExit;
@@ -47,6 +48,36 @@ describe('Publish-please CLI Options', () => {
         // Given
         process.env['npm_config_argv'] =
             '{"remain":[],"cooked":["run","publish-please","--dry-run"],"original":["run","publish-please","--dry-run"]}';
+        // When
+        return (
+            cli()
+                // Then
+                .catch((err) => err.message.should.containEql('ERRORS'))
+                .catch((err) => output.should.containEql('dry mode activated'))
+        );
+    });
+
+    it('Should execute dry-run workflow on `npx publish-please --dry-run`', () => {
+        // Given
+        process.env['npm_config_argv'] = undefined;
+
+        // [ '/usr/local/bin/node',
+        //   '/Users/HDO/.npm/_npx/97852/bin/publish-please',
+        //   '--dry-run'
+        // ]
+        process.argv = [
+            pathJoin('usr', 'local', 'bin', 'node'),
+            pathJoin(
+                'Users',
+                'xxx',
+                '.npm',
+                '_npx',
+                '97852',
+                'bin',
+                'publish-please'
+            ),
+            '--dry-run',
+        ];
         // When
         return (
             cli()

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -100,7 +100,7 @@ describe('Publish-please CLI Options', () => {
         );
     });
 
-    it('Should execute publihing workflow on `npx publish-please`', () => {
+    it('Should execute publishing workflow on `npx publish-please`', () => {
         // Given
         process.env['npm_config_argv'] = undefined;
 
@@ -126,12 +126,10 @@ describe('Publish-please CLI Options', () => {
             cli()
                 // Then
                 .catch((err) => {
+                    output.should.not.containEql('dry mode activated');
                     output.should.containEql('Running pre-publish script');
                     output.should.containEql('Running validations');
                     output.should.containEql('ERRORS');
-                    output.should.containEql(
-                        'There are uncommitted changes in the working tree.'
-                    );
                 })
         );
     });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,6 +6,7 @@ const writeFile = require('fs').writeFileSync;
 const should = require('should');
 const cli = require('../lib');
 const pathJoin = require('path').join;
+const packageName = require('./utils/publish-please-version-under-test');
 
 /** !!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * These tests runs publish-please code on publish-please repo itself
@@ -19,7 +20,14 @@ describe('Publish-please CLI Options', () => {
     let exitCode;
     let output;
     let hasAddedArg;
+    let originalConfiguration;
 
+    before(() => {
+        originalConfiguration = JSON.parse(readFile('.publishrc').toString());
+    });
+    after(() => {
+        writeFile('.publishrc', JSON.stringify(originalConfiguration, null, 2));
+    });
     beforeEach(() => {
         hasAddedArg = false;
         process.env.PUBLISH_PLEASE_TEST_MODE = true;
@@ -50,9 +58,7 @@ describe('Publish-please CLI Options', () => {
             process.argv.pop();
         }
 
-        const publishrc = JSON.parse(readFile('.publishrc').toString());
-        publishrc.prePublishScript = "echo 'npm test'";
-        writeFile('.publishrc', JSON.stringify(publishrc, null, 2));
+        writeFile('.publishrc', JSON.stringify(originalConfiguration, null, 2));
     });
 
     it('Should execute dry-run workflow on `npm run publish-please --dry-run`', () => {
@@ -70,7 +76,35 @@ describe('Publish-please CLI Options', () => {
         );
     });
 
-    it('Should execute dry-run workflow on `npx publish-please --dry-run`', () => {
+    it('Should execute dry-run workflow with no errors on `npm run publish-please --dry-run`', () => {
+        // Given
+        process.env['npm_config_argv'] =
+            '{"remain":[],"cooked":["run","publish-please","--dry-run"],"original":["run","publish-please","--dry-run"]}';
+        const publishrc = JSON.parse(readFile('.publishrc').toString());
+        publishrc.confirm = false;
+        publishrc.validations.uncommittedChanges = false;
+        publishrc.validations.gitTag = false;
+        publishrc.validations.branch = false;
+        writeFile('.publishrc', JSON.stringify(publishrc, null, 2));
+
+        // When
+        return (
+            cli()
+                // Then
+                .then(() => {
+                    output.should.not.containEql('ERRORS');
+                    output.should.containEql('dry mode activated');
+                    output.should.containEql('Running pre-publish script');
+                    output.should.containEql('Running validations');
+                    output.should.containEql('Release info');
+                    output.should.containEql(
+                        "run 'npm pack' to have more details on the package"
+                    );
+                })
+        );
+    });
+
+    it('Should execute dry-run workflow with errors on `npx publish-please --dry-run`', () => {
         // Given
         process.env['npm_config_argv'] = undefined;
 
@@ -95,8 +129,54 @@ describe('Publish-please CLI Options', () => {
         return (
             cli()
                 // Then
-                .catch((err) => err.message.should.containEql('ERRORS'))
-                .catch((err) => output.should.containEql('dry mode activated'))
+                .catch((err) => {
+                    output.should.containEql('dry mode activated');
+                    output.should.containEql('ERRORS');
+                })
+        );
+    });
+
+    it('Should execute dry-run workflow with no errors on `npx publish-please --dry-run`', () => {
+        // Given
+        process.env['npm_config_argv'] = undefined;
+
+        // [ '/usr/local/bin/node',
+        //   '/Users/HDO/.npm/_npx/97852/bin/publish-please',
+        //   '--dry-run'
+        // ]
+        process.argv = [
+            pathJoin('usr', 'local', 'bin', 'node'),
+            pathJoin(
+                'Users',
+                'xxx',
+                '.npm',
+                '_npx',
+                '97852',
+                'bin',
+                'publish-please'
+            ),
+            '--dry-run',
+        ];
+        const publishrc = JSON.parse(readFile('.publishrc').toString());
+        publishrc.confirm = false;
+        publishrc.validations.uncommittedChanges = false;
+        publishrc.validations.gitTag = false;
+        publishrc.validations.branch = false;
+        writeFile('.publishrc', JSON.stringify(publishrc, null, 2));
+        // When
+        return (
+            cli()
+                // Then
+                .then(() => {
+                    output.should.not.containEql('ERRORS');
+                    output.should.containEql('dry mode activated');
+                    output.should.containEql('Running pre-publish script');
+                    output.should.containEql('Running validations');
+                    output.should.containEql('Release info');
+                    output.should.containEql(
+                        "run 'npm pack' to have more details on the package"
+                    );
+                })
         );
     });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -19,8 +19,8 @@ describe('Publish-please CLI Options', () => {
     let nativeConsoleLog;
     let exitCode;
     let output;
-    let hasAddedArg;
     let originalConfiguration;
+    let originalArgv;
 
     before(() => {
         originalConfiguration = JSON.parse(readFile('.publishrc').toString());
@@ -29,7 +29,6 @@ describe('Publish-please CLI Options', () => {
         writeFile('.publishrc', JSON.stringify(originalConfiguration, null, 2));
     });
     beforeEach(() => {
-        hasAddedArg = false;
         process.env.PUBLISH_PLEASE_TEST_MODE = true;
         exitCode = undefined;
         output = '';
@@ -44,6 +43,8 @@ describe('Publish-please CLI Options', () => {
             output = output + p1;
         };
 
+        originalArgv = process.argv.map((arg) => arg);
+
         // patch the .publisrc file to make sure publishing will fail
         const publishrc = JSON.parse(readFile('.publishrc').toString());
         publishrc.prePublishScript =
@@ -54,9 +55,7 @@ describe('Publish-please CLI Options', () => {
         process.exit = nativeExit;
         console.log = nativeConsoleLog;
         delete process.env.PUBLISH_PLEASE_TEST_MODE;
-        if (hasAddedArg) {
-            process.argv.pop();
-        }
+        process.argv = originalArgv;
 
         writeFile('.publishrc', JSON.stringify(originalConfiguration, null, 2));
     });
@@ -266,7 +265,6 @@ describe('Publish-please CLI Options', () => {
         process.env['npm_config_argv'] =
             '{"remain":[],"cooked":["publish"],"original":["publish"]}';
         process.argv.push('guard');
-        hasAddedArg = true;
         // When
         cli();
         // Then

--- a/test/post-install.spec.js
+++ b/test/post-install.spec.js
@@ -245,4 +245,20 @@ describe('Post-Install Execution', () => {
             );
         }
     });
+
+    it(`Should not run postinstall script on 'npx ${packageName}'`, () => {
+        // Given
+        const npxPath = JSON.stringify(
+            pathJoin('Users', 'HDO', '.npm', '_npx', '78031')
+        );
+        process.env[
+            'npm_config_argv'
+        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix",${npxPath},"--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix",${npxPath},"--loglevel","error","--json"]}`;
+
+        // When
+        requireUncached('../lib/post-install');
+        // Then
+        (exitCode || 0).should.be.equal(0);
+        output.should.be.equal('');
+    });
 });

--- a/test/pre-install.spec.js
+++ b/test/pre-install.spec.js
@@ -87,10 +87,12 @@ describe('Pre-Install Execution', () => {
 
     it(`Should not return an error message on 'npx ${packageName}'`, () => {
         // Given
-        const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
+        const npxPath = JSON.stringify(
+            pathJoin('Users', 'HDO', '.npm', '_npx', '78031')
+        );
         process.env[
             'npm_config_argv'
-        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"]}`;
+        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix",${npxPath},"--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix",${npxPath},"--loglevel","error","--json"]}`;
 
         // When
         requireUncached('../lib/pre-install');

--- a/test/pre-install.spec.js
+++ b/test/pre-install.spec.js
@@ -6,6 +6,7 @@ const requireUncached = require('import-fresh');
 const packageName = require('./utils/publish-please-version-under-test');
 const copy = require('./utils/copy-file-sync');
 const mkdirp = require('mkdirp');
+const pathJoin = require('path').join;
 
 describe('Pre-Install Execution', () => {
     let nativeExit;
@@ -86,9 +87,10 @@ describe('Pre-Install Execution', () => {
 
     it(`Should not return an error message on 'npx ${packageName}'`, () => {
         // Given
+        const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
         process.env[
             'npm_config_argv'
-        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"]}`;
+        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"]}`;
 
         // When
         requireUncached('../lib/pre-install');

--- a/test/pre-install.spec.js
+++ b/test/pre-install.spec.js
@@ -70,4 +70,30 @@ describe('Pre-Install Execution', () => {
         (exitCode || 0).should.be.equal(0);
         output.should.be.equal('');
     });
+
+    it('Should not return an error message if npm args are not recognized', () => {
+        // Given
+        process.env[
+            'npm_config_argv'
+        ] = `{"remain":["${packageName}],"cooked":["install","--global","${packageName}"],"original":["install","-g","${packageName}"]}`;
+
+        // When
+        requireUncached('../lib/pre-install');
+        // Then
+        (exitCode || 0).should.be.equal(0);
+        output.should.be.equal('');
+    });
+
+    it(`Should not return an error message on 'npx ${packageName}'`, () => {
+        // Given
+        process.env[
+            'npm_config_argv'
+        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix","/Users/HDO/.npm/_npx/78031","--loglevel","error","--json"]}`;
+
+        // When
+        requireUncached('../lib/pre-install');
+        // Then
+        (exitCode || 0).should.be.equal(0);
+        output.should.be.equal('');
+    });
 });

--- a/test/prevent-global-install.spec.js
+++ b/test/prevent-global-install.spec.js
@@ -63,10 +63,12 @@ describe('Prevent Global Install', () => {
 
     it(`Should not throw an error when chalk module is not found on 'npx ${packageName}'`, () => {
         // Given
-        const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
+        const npxPath = JSON.stringify(
+            pathJoin('Users', 'HDO', '.npm', '_npx', '78031')
+        );
         process.env[
             'npm_config_argv'
-        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"]}`;
+        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix",${npxPath},"--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix",${npxPath},"--loglevel","error","--json"]}`;
 
         // When
         preventGlobalInstall();

--- a/test/prevent-global-install.spec.js
+++ b/test/prevent-global-install.spec.js
@@ -6,6 +6,7 @@ const should = require('should');
 const packageName = require('./utils/publish-please-version-under-test');
 const preventGlobalInstall = require('../lib/prevent-global-install');
 const rename = require('fs').renameSync;
+const pathJoin = require('path').join;
 
 describe('Prevent Global Install', () => {
     let nativeExit;
@@ -39,7 +40,7 @@ describe('Prevent Global Install', () => {
         process.env[
             'npm_config_argv'
         ] = `{"remain":["${packageName}"],"cooked":["install","--global","${packageName}"],"original":["install","-g","${packageName}"]}`;
-        //
+
         // When
         preventGlobalInstall();
         // Then
@@ -52,7 +53,21 @@ describe('Prevent Global Install', () => {
         process.env[
             'npm_config_argv'
         ] = `{"remain":["${packageName}"],"cooked":["install","--save-dev","${packageName}"],"original":["install","--save-dev","${packageName}"]}`;
-        //
+
+        // When
+        preventGlobalInstall();
+        // Then
+        (exitCode || 0).should.be.equal(0);
+        output.should.be.equal('');
+    });
+
+    it(`Should not throw an error when chalk module is not found on 'npx ${packageName}'`, () => {
+        // Given
+        const npxPath = pathJoin('Users', 'HDO', '.npm', '_npx', '78031');
+        process.env[
+            'npm_config_argv'
+        ] = `{"remain":["${packageName}"],"cooked":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"],"original":["install","${packageName}","--global","--prefix","${npxPath}","--loglevel","error","--json"]}`;
+
         // When
         preventGlobalInstall();
         // Then

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/* eslint-disable no-unused-vars */
+const should = require('should');
+
 const assert = require('assert');
 const del = require('del');
 const writeFile = require('fs').writeFileSync;
@@ -1452,6 +1455,38 @@ describe('Integration tests', () => {
                     assert(publishLog.includes('testing-repo-1.3.77.tgz'));
                     /* prettier-ignore */
                     assert(publishLog.includes("run 'npm pack' to have more details on the package"));
+                });
+        });
+
+        it(`Should be able to configure publish-please with 'npx ${packageName} config'`, () => {
+            return Promise.resolve()
+                .then(() => console.log(`> npx ${packageName} config`))
+                .then(() =>
+                    exec(
+                        /* prettier-ignore */
+                        `npx ../${packageName.replace('@','-')}.tgz config > ./publish.log`
+                    )
+                )
+                .then(() => {
+                    const publishLog = readFile('./publish.log').toString();
+                    console.log(publishLog);
+                })
+                .then(() => {
+                    const publishrc = JSON.parse(
+                        readFile('.publishrc').toString()
+                    );
+                    publishrc.confirm.should.be.true();
+                    publishrc.prePublishScript.should.equal('npm test');
+                    publishrc.postPublishScript.should.equal('');
+                    publishrc.publishCommand.should.equal('npm publish');
+                    publishrc.publishTag.should.equal('latest');
+                    publishrc.validations.branch.should.equal('master');
+                    publishrc.validations.uncommittedChanges.should.be.true();
+                    publishrc.validations.untrackedFiles.should.be.true();
+                    publishrc.validations.vulnerableDependencies.should.be.true();
+                    publishrc.validations.sensitiveData.should.be.true();
+                    publishrc.validations.gitTag.should.be.true();
+                    publishrc.validations.branch.should.equal('master');
                 });
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1368,17 +1368,16 @@ describe('Integration tests', () => {
                     scripts.test = 'echo "running tests ..."';
                     pkg.scripts = scripts;
                     writeFile('package.json', JSON.stringify(pkg, null, 2));
-                    return Promise.resolve();
                 })
                 .then(() => console.log(`> npx ${packageName} --dry-run`))
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz --dry-run > ./publish.log`
+                        `npx ../${packageName.replace('@','-')}.tgz --dry-run > ./publish01.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish.log').toString();
+                    const publishLog = readFile('./publish01.log').toString();
                     console.log(publishLog);
                     /* prettier-ignore */
                     assert(publishLog.includes('dry mode activated'));
@@ -1403,7 +1402,6 @@ describe('Integration tests', () => {
                     scripts.test = 'echo "running tests ..."';
                     pkg.scripts = scripts;
                     writeFile('package.json', JSON.stringify(pkg, null, 2));
-                    return Promise.resolve();
                 })
                 .then(() => {
                     writeFile(
@@ -1429,11 +1427,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz --dry-run > ./publish.log`
+                        `npx ../${packageName.replace('@','-')}.tgz --dry-run > ./publish02.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish.log').toString();
+                    const publishLog = readFile('./publish02.log').toString();
                     console.log(publishLog);
                     /* prettier-ignore */
                     assert(publishLog.includes('dry mode activated'));
@@ -1464,11 +1462,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz config > ./publish.log`
+                        `npx ../${packageName.replace('@','-')}.tgz config > ./publish03.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish.log').toString();
+                    const publishLog = readFile('./publish03.log').toString();
                     console.log(publishLog);
                 })
                 .then(() => {
@@ -1493,15 +1491,14 @@ describe('Integration tests', () => {
         it(`Should be able to start the publishing workflow with 'npx ${packageName}' (no .publishrc config file)`, () => {
             return Promise.resolve()
                 .then(() => console.log(`> npx ${packageName}`))
-
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish04.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish.log').toString();
+                    const publishLog = readFile('./publish04.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })
@@ -1541,7 +1538,6 @@ describe('Integration tests', () => {
                     scripts.test = 'echo "running tests ..."';
                     pkg.scripts = scripts;
                     writeFile('package.json', JSON.stringify(pkg, null, 2));
-                    return Promise.resolve();
                 })
                 .then(() => {
                     writeFile(
@@ -1567,11 +1563,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish05.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish.log').toString();
+                    const publishLog = readFile('./publish05.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })

--- a/test/test.js
+++ b/test/test.js
@@ -1357,7 +1357,7 @@ describe('Integration tests', () => {
     });
 
     describe('npx usage', () => {
-        it(`Should be able to use publish-please in dry mode (with no .publishrc config file) with npx ${packageName} --dry-run`, () => {
+        it(`Should be able to use publish-please in dry mode (with no .publishrc config file) with 'npx ${packageName} --dry-run'`, () => {
             return Promise.resolve()
                 .then(() => {
                     const pkg = JSON.parse(readFile('package.json').toString());
@@ -1367,6 +1367,7 @@ describe('Integration tests', () => {
                     writeFile('package.json', JSON.stringify(pkg, null, 2));
                     return Promise.resolve();
                 })
+                .then(() => console.log(`> npx ${packageName} --dry-run`))
                 .then(() =>
                     exec(
                         /* prettier-ignore */
@@ -1388,6 +1389,69 @@ describe('Integration tests', () => {
                     assert(publishLog.includes('ERRORS'));
                     /* prettier-ignore */
                     assert(publishLog.includes('There are uncommitted changes in the working tree.'));
+                });
+        });
+
+        it(`Should be able to use publish-please in dry mode (with existing .publishrc config file) with 'npx ${packageName} --dry-run'`, () => {
+            return Promise.resolve()
+                .then(() => {
+                    const pkg = JSON.parse(readFile('package.json').toString());
+                    const scripts = {};
+                    scripts.test = 'echo "running tests ..."';
+                    pkg.scripts = scripts;
+                    writeFile('package.json', JSON.stringify(pkg, null, 2));
+                    return Promise.resolve();
+                })
+                .then(() => {
+                    writeFile(
+                        '.publishrc',
+                        JSON.stringify({
+                            confirm: true,
+                            validations: {
+                                vulnerableDependencies: true,
+                                sensitiveData: false,
+                                uncommittedChanges: false,
+                                untrackedFiles: false,
+                                branch: 'master',
+                                gitTag: false,
+                            },
+                            publishTag: 'latest',
+                            prePublishScript:
+                                'echo "running script defined in .publishrc ..."',
+                            postPublishScript: false,
+                        })
+                    );
+                })
+                .then(() => console.log(`> npx ${packageName} --dry-run`))
+                .then(() =>
+                    exec(
+                        /* prettier-ignore */
+                        `npx ../${packageName.replace('@','-')}.tgz --dry-run > ./publish.log`
+                    )
+                )
+                .then(() => {
+                    const publishLog = readFile('./publish.log').toString();
+                    console.log(publishLog);
+                    /* prettier-ignore */
+                    assert(publishLog.includes('dry mode activated'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running pre-publish script'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('running script defined in .publishrc ...'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running validations'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Checking for the vulnerable dependencies'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Validating branch'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('ERRORS'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Release info'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('testing-repo-1.3.77.tgz'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes("run 'npm pack' to have more details on the package"));
                 });
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,7 @@ describe('Integration tests', () => {
     const publish = requireUncached('../lib/publish/publish-workflow');
     const getOptions = require('../lib/publish-options').getOptions;
     const echoPublishCommand = 'echo "npm publish"';
+
     function mkdir(path) {
         return new Promise((resolve, reject) =>
             mkdirp(path, null, (err) => (err ? reject(err) : resolve()))
@@ -174,7 +175,11 @@ describe('Integration tests', () => {
         it('Should expect `master` branch by default', () =>
             exec('git checkout some-branch')
                 .then(() =>
-                    publish(getTestOptions({ remove: 'validations.branch' }))
+                    publish(
+                        getTestOptions({
+                            remove: 'validations.branch',
+                        })
+                    )
                 )
                 .then(() => {
                     throw new Error('Promise rejection expected');
@@ -191,7 +196,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     publish(
                         getTestOptions({
-                            set: { validations: { branch: 'no-package-json' } },
+                            set: {
+                                validations: {
+                                    branch: 'no-package-json',
+                                },
+                            },
                         })
                     )
                 )
@@ -210,7 +219,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     publish(
                         getTestOptions({
-                            set: { validations: { branch: 'master' } },
+                            set: {
+                                validations: {
+                                    branch: 'master',
+                                },
+                            },
                         })
                     )
                 )
@@ -229,7 +242,9 @@ describe('Integration tests', () => {
                     getTestOptions({
                         set: {
                             publishCommand: echoPublishCommand,
-                            validations: { branch: 'some-branch' },
+                            validations: {
+                                branch: 'some-branch',
+                            },
                         },
                     })
                 )
@@ -260,7 +275,9 @@ describe('Integration tests', () => {
                     publish(
                         getTestOptions({
                             set: {
-                                validations: { gitTag: true },
+                                validations: {
+                                    gitTag: true,
+                                },
                             },
                         })
                     )
@@ -280,7 +297,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     publish(
                         getTestOptions({
-                            set: { validations: { gitTag: true } },
+                            set: {
+                                validations: {
+                                    gitTag: true,
+                                },
+                            },
                         })
                     )
                 )
@@ -302,7 +323,9 @@ describe('Integration tests', () => {
                         getTestOptions({
                             set: {
                                 publishCommand: echoPublishCommand,
-                                validations: { gitTag: true },
+                                validations: {
+                                    gitTag: true,
+                                },
                             },
                         })
                     )
@@ -333,7 +356,11 @@ describe('Integration tests', () => {
 
                     return publish(
                         getTestOptions({
-                            set: { validations: { uncommittedChanges: true } },
+                            set: {
+                                validations: {
+                                    uncommittedChanges: true,
+                                },
+                            },
                         })
                     );
                 })
@@ -369,7 +396,9 @@ describe('Integration tests', () => {
                     getTestOptions({
                         set: {
                             publishCommand: echoPublishCommand,
-                            validations: { uncommittedChanges: true },
+                            validations: {
+                                uncommittedChanges: true,
+                            },
                         },
                     })
                 )
@@ -384,7 +413,11 @@ describe('Integration tests', () => {
 
                     return publish(
                         getTestOptions({
-                            set: { validations: { untrackedFiles: true } },
+                            set: {
+                                validations: {
+                                    untrackedFiles: true,
+                                },
+                            },
                         })
                     );
                 })
@@ -406,7 +439,9 @@ describe('Integration tests', () => {
                     getTestOptions({
                         set: {
                             publishCommand: echoPublishCommand,
-                            validations: { untrackedFiles: false },
+                            validations: {
+                                untrackedFiles: false,
+                            },
                         },
                     })
                 );
@@ -418,7 +453,9 @@ describe('Integration tests', () => {
                     getTestOptions({
                         set: {
                             publishCommand: echoPublishCommand,
-                            validations: { untrackedFiles: true },
+                            validations: {
+                                untrackedFiles: true,
+                            },
                         },
                     })
                 )
@@ -437,7 +474,11 @@ describe('Integration tests', () => {
                 .then(() =>
                     publish(
                         getTestOptions({
-                            set: { validations: { sensitiveData: true } },
+                            set: {
+                                validations: {
+                                    sensitiveData: true,
+                                },
+                            },
                         })
                     )
                 )
@@ -495,7 +536,9 @@ describe('Integration tests', () => {
                         getTestOptions({
                             set: {
                                 publishCommand: echoPublishCommand,
-                                validations: { sensitiveData: false },
+                                validations: {
+                                    sensitiveData: false,
+                                },
                             },
                         })
                     )
@@ -507,14 +550,18 @@ describe('Integration tests', () => {
             exec('git checkout master')
                 .then(() => pkgd())
                 .then((pkgInfo) => {
-                    pkgInfo.cfg.dependencies = { ms: '0.7.0' };
+                    pkgInfo.cfg.dependencies = {
+                        ms: '0.7.0',
+                    };
                     writeFile('package.json', JSON.stringify(pkgInfo.cfg));
                 })
                 .then(() =>
                     publish(
                         getTestOptions({
                             set: {
-                                validations: { vulnerableDependencies: true },
+                                validations: {
+                                    vulnerableDependencies: true,
+                                },
                             },
                         })
                     )
@@ -687,7 +734,9 @@ describe('Integration tests', () => {
             exec('git checkout master')
                 .then(() => pkgd())
                 .then((pkgInfo) => {
-                    pkgInfo.cfg.dependencies = { ms: '0.7.1' };
+                    pkgInfo.cfg.dependencies = {
+                        ms: '0.7.1',
+                    };
                     writeFile('package.json', JSON.stringify(pkgInfo.cfg));
                 })
                 .then(() =>
@@ -695,7 +744,9 @@ describe('Integration tests', () => {
                         getTestOptions({
                             set: {
                                 publishCommand: echoPublishCommand,
-                                validations: { vulnerableDependencies: true },
+                                validations: {
+                                    vulnerableDependencies: true,
+                                },
                             },
                         })
                     )
@@ -729,7 +780,9 @@ describe('Integration tests', () => {
                         getTestOptions({
                             set: {
                                 publishCommand: echoPublishCommand,
-                                validations: { vulnerableDependencies: true },
+                                validations: {
+                                    vulnerableDependencies: true,
+                                },
                             },
                         })
                     )
@@ -749,7 +802,9 @@ describe('Integration tests', () => {
                     publish(
                         getTestOptions({
                             set: {
-                                validations: { vulnerableDependencies: true },
+                                validations: {
+                                    vulnerableDependencies: true,
+                                },
                             },
                         })
                     )
@@ -768,7 +823,9 @@ describe('Integration tests', () => {
             exec('git checkout master')
                 .then(() => pkgd())
                 .then((pkgInfo) => {
-                    pkgInfo.cfg.dependencies = { ms: '0.7.0' };
+                    pkgInfo.cfg.dependencies = {
+                        ms: '0.7.0',
+                    };
 
                     writeFile('package.json', JSON.stringify(pkgInfo.cfg));
                 })
@@ -777,7 +834,9 @@ describe('Integration tests', () => {
                         getTestOptions({
                             set: {
                                 publishCommand: echoPublishCommand,
-                                validations: { vulnerableDependencies: false },
+                                validations: {
+                                    vulnerableDependencies: false,
+                                },
                             },
                         })
                     )
@@ -916,7 +975,9 @@ describe('Integration tests', () => {
                 .then(() =>
                     publish(
                         getTestOptions({
-                            set: { publishCommand: echoPublishCommand },
+                            set: {
+                                publishCommand: echoPublishCommand,
+                            },
                             remove: 'publishTag',
                         })
                     )
@@ -1019,9 +1080,9 @@ describe('Integration tests', () => {
                 .catch((err) => {
                     // prettier-ignore
                     assert(
-                        err.message.indexOf('You do not have permission to publish') > -1
-                        || err.message.indexOf('auth required for publishing') > -1
-                        || err.message.indexOf('operation not permitted') > -1
+                        err.message.indexOf('You do not have permission to publish') > -1 ||
+                        err.message.indexOf('auth required for publishing') > -1 ||
+                        err.message.indexOf('operation not permitted') > -1
                     );
                 }));
 
@@ -1291,6 +1352,42 @@ describe('Integration tests', () => {
                     assert(publishLog.includes('testing-repo-1.3.77.tgz'));
                     /* prettier-ignore */
                     assert(publishLog.includes("run 'npm pack' to have more details on the package"));
+                });
+        });
+    });
+
+    describe('npx usage', () => {
+        it(`Should be able to use publish-please in dry mode (with no .publishrc config file) with npx ${packageName} --dry-run`, () => {
+            return Promise.resolve()
+                .then(() => {
+                    const pkg = JSON.parse(readFile('package.json').toString());
+                    const scripts = {};
+                    scripts.test = 'echo "running tests ..."';
+                    pkg.scripts = scripts;
+                    writeFile('package.json', JSON.stringify(pkg, null, 2));
+                    return Promise.resolve();
+                })
+                .then(() =>
+                    exec(
+                        /* prettier-ignore */
+                        `npx ../${packageName.replace('@','-')}.tgz --dry-run > ./publish.log`
+                    )
+                )
+                .then(() => {
+                    const publishLog = readFile('./publish.log').toString();
+                    console.log(publishLog);
+                    /* prettier-ignore */
+                    assert(publishLog.includes('dry mode activated'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running pre-publish script'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('running tests ...'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running validations'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('ERRORS'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('There are uncommitted changes in the working tree.'));
                 });
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1032,9 +1032,13 @@ describe('Integration tests', () => {
         beforeEach(() => {
             return mkdir(
                 'node_modules/publish-please/lib'.replace(/\\|\//g, sep)
-            ).then(() =>
-                exec('cp -r ../lib/* node_modules/publish-please/lib')
-            );
+            )
+                .then(() =>
+                    exec('cp -r ../lib/* node_modules/publish-please/lib')
+                )
+                .then(() => {
+                    process.env['npm_config_argv'] = '';
+                });
         });
 
         it('Should add hooks to package.json', () =>

--- a/test/test.js
+++ b/test/test.js
@@ -1593,7 +1593,7 @@ describe('Integration tests', () => {
                     /* prettier-ignore */
                     assert(publishLog.includes('ERRORS'));
                     /* prettier-ignore */
-                    assert(publishLog.includes('Command `npm` exited with code 1'));
+                    assert(publishLog.includes('Command `npm` exited with code'));
                 });
         });
     });


### PR DESCRIPTION
As a package publisher, it would be nice to publish my package by just running one of these commands:

**publish in a dry-run mode**
```sh
npx publish-please --dry-run
```

**safely publish to the npm registry**
```sh
npx publish-please
```

**setup a configuration file in order to customise my publishing workflow**
```sh
npx publish-please config
```
