### PR TITLE
feat(validation): add branch validation via regular expression

### DIFF
--- a/src/validations/branch.js
+++ b/src/validations/branch.js
@@ -27,7 +27,14 @@ module.exports = {
                     .replace('* ', '')
             )
             .then((branch) => {
-                if (branch !== expected)
+                if (expected.match(/^\/.*\/$/)) {
+                    const regexp = new RegExp(
+                        expected.replace(/^\/(.*)\/$/, '$1')
+                    );
+                    if (!regexp.test(branch)) {
+                        throw `Expected branch to match ${expected}, but it was '${branch}'.`;
+                    }
+                } else if (branch !== expected)
                     throw `Expected branch to be '${expected}', but it was '${branch}'.`;
             });
     },

--- a/test/12-integration-tests.js
+++ b/test/12-integration-tests.js
@@ -221,6 +221,29 @@ describe('Integration tests', () => {
                     )
                 ));
 
+        it('Should validate the branch set in the configuration file via RegExp', () =>
+            exec('git checkout some-branch')
+                .then(() =>
+                    publish(
+                        getTestOptions({
+                            set: {
+                                validations: {
+                                    branch: '/(^master$|^release\\/)/',
+                                },
+                            },
+                        })
+                    )
+                )
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch((err) =>
+                    assert.strictEqual(
+                        err.message,
+                        "  * Expected branch to match /(^master$|^release\\/)/, but it was 'some-branch'."
+                    )
+                ));
+
         it('Should expect the latest commit in the branch', () =>
             exec('git checkout 15a1ef78338cf1fa60c318828970b2b3e70004d1')
                 .then(() =>
@@ -251,6 +274,20 @@ describe('Integration tests', () => {
                             publishCommand: echoPublishCommand,
                             validations: {
                                 branch: 'some-branch',
+                            },
+                        },
+                    })
+                )
+            ));
+
+        it('Should pass branch validation via RegExp', () =>
+            exec('git checkout master').then(() =>
+                publish(
+                    getTestOptions({
+                        set: {
+                            publishCommand: echoPublishCommand,
+                            validations: {
+                                branch: '/(^master$|^release\\/)/',
                             },
                         },
                     })


### PR DESCRIPTION
In some conditions, you have no single branch to release from (e.g. git flow), so I added an option to validate via regular expressions.