### PR TITLE
fix tgz file is left in project directory after publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## [5.1.1] - 2018-11-01
-### Unreleased
+## [5.1.1] - 2018-10-30
+### Fixed
 - fix: tgz file is left in project directory after publishing 
 
 ## [5.1.0] - 2018-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [5.1.1] - 2018-11-01
+### Unreleased
+- fix: tgz file is left in project directory after publishing 
+
 ## [5.1.0] - 2018-10-29
 ### Changed
 - update/remove dependencies 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {

--- a/test/10-npm-audit-package-when-npm-version-gte-5.9.0.spec.js
+++ b/test/10-npm-audit-package-when-npm-version-gte-5.9.0.spec.js
@@ -9,6 +9,7 @@ const del = require('del');
 const auditPackage = require('../lib/utils/npm-audit-package');
 const writeFile = require('fs').writeFileSync;
 const touch = require('./utils/touch-file-sync');
+const fileExists = require('fs').existsSync;
 
 const lineSeparator = '----------------------------------';
 
@@ -70,6 +71,47 @@ if (nodeInfos.npmPackHasJsonReporter) {
                             bundled: [],
                         };
                         result.should.containDeep(expected);
+                    })
+            );
+        });
+
+        it('Should remove the generated package tar file', () => {
+            // Given
+            const pkg = {
+                name: 'testing-repo',
+                version: '0.0.0',
+                scripts: {},
+            };
+            writeFile(
+                pathJoin(projectDir, 'package.json'),
+                JSON.stringify(pkg, null, 2)
+            );
+
+            // When
+            return (
+                Promise.resolve()
+                    .then(() => auditPackage(projectDir))
+
+                    // Then
+                    .then((result) => {
+                        const expected = {
+                            id: 'testing-repo@0.0.0',
+                            name: 'testing-repo',
+                            version: '0.0.0',
+                            filename: 'testing-repo-0.0.0.tgz',
+                            files: [
+                                {
+                                    path: 'package.json',
+                                    size: 67,
+                                    isSensitiveData: false,
+                                },
+                            ],
+                            entryCount: 1,
+                            bundled: [],
+                        };
+                        result.should.containDeep(expected);
+                        Array.isArray(result.internalErrors).should.be.false();
+                        fileExists(expected.filename).should.be.false();
                     })
             );
         });

--- a/test/10-npm-audit-package.spec.js
+++ b/test/10-npm-audit-package.spec.js
@@ -492,11 +492,17 @@ describe('npm package analyzer', () => {
             ],
             entryCount: 2,
             bundled: [],
-            internalErrors: [
-                { message: 'The "path" argument must be of type string' },
-            ],
         };
         result.should.containDeep(expected);
+        Array.isArray(result.internalErrors).should.be.true();
+        (
+            result.internalErrors[0].message.includes(
+                'The "path" argument must be of type string'
+            ) ||
+            result.internalErrors[0].message.includes(
+                'Path must be a string. Received null'
+            )
+        ).should.be.true();
     });
 
     it('Should remove the generated package', () => {


### PR DESCRIPTION
The goal of this PR is to solve issue #82.

`sensitive and non-essential data` validation creates an npm package of the current project. This package file should be automatically removed after the validation has run.