### PR TITLE
Be able to override .sensitivedata on per project basis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [5.2.0] - 2018-11-05
+### Unreleased
+- be able to override .sensitivedata on per project basis
+
 ## [5.1.1] - 2018-10-30
 ### Fixed
 - fix: tgz file is left in project directory after publishing 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## [5.2.0] - 2018-11-05
-### Unreleased
+## [5.2.0] - 2018-11-04
+### Added
 - be able to override .sensitivedata on per project basis
 
 ## [5.1.1] - 2018-10-30

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 <p align="center">
 <i>Safe and highly functional replacement for `npm publish`.</i>
 </p>
+
+<p align="center">
+<i>You could also use publish-please only as an ultimate check before publishing: `npx publish-please --dry-run`</i>
+</p>
+
 <p align="center">
     <img src="https://raw.githubusercontent.com/inikulin/publish-please/master/media/demo.gif" alt="demo" />
 </p>
@@ -75,6 +80,7 @@ npm run publish-please
  - **sensitive and non essential Data** - Perform [audit for the sensitive data](#sensitive-and-non-essential-data-audit). Default: `true` if npm version is 5.9.0 or above, `false` otherwise.
     - sensitive and non-essential data are by default defined inside this [.sensitivedata](.sensitivedata) file.
     - you may completely override this file by creating a `.sensitivedata` file in the root of your project so that this validation fits your needs.
+        - if you create your own `.sensitivedata` file, and the `package.json` file has no `files` section, consider adding `.sensitivedata` to the `.npmignore` file.
     
  - **vulnerableDependencies** - Perform vulnerable dependencies check using `npm audit`. Default: `true` if npm version is 6.1.0 or above, `false` otherwise.
     - you may prevent specific vulnerabilities to be reported by publish-please by creating a `.auditignore` file in the root of your project with content like the following:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm run publish-please
         ``` 
  - **sensitive and non essential Data** - Perform [audit for the sensitive data](#sensitive-and-non-essential-data-audit). Default: `true` if npm version is 5.9.0 or above, `false` otherwise.
     - sensitive and non-essential data are by default defined inside this [.sensitivedata](.sensitivedata) file.
-    - you may override this file by creating a `.sensitivedata` file in the root of your project so that this validation fits your needs.
+    - you may completely override this file by creating a `.sensitivedata` file in the root of your project so that this validation fits your needs.
     
  - **vulnerableDependencies** - Perform vulnerable dependencies check using `npm audit`. Default: `true` if npm version is 6.1.0 or above, `false` otherwise.
     - you may prevent specific vulnerabilities to be reported by publish-please by creating a `.auditignore` file in the root of your project with content like the following:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ npm run publish-please
         /(master|release)/
         ``` 
  - **sensitive and non essential Data** - Perform [audit for the sensitive data](#sensitive-and-non-essential-data-audit). Default: `true` if npm version is 5.9.0 or above, `false` otherwise.
+    - sensitive and non-essential data are by default defined inside this [.sensitivedata](.sensitivedata) file.
+    - you may override this file by creating a `.sensitivedata` file in the root of your project so that this validation fits your needs.
+    
  - **vulnerableDependencies** - Perform vulnerable dependencies check using `npm audit`. Default: `true` if npm version is 6.1.0 or above, `false` otherwise.
     - you may prevent specific vulnerabilities to be reported by publish-please by creating a `.auditignore` file in the root of your project with content like the following:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {

--- a/src/utils/npm-audit-package.js
+++ b/src/utils/npm-audit-package.js
@@ -217,8 +217,8 @@ module.exports.getDefaultOptionsFor = getDefaultOptionsFor;
 
 /**
  * get all sensitive data from the '.sensitivedata' file
- * If a sensitive data is found in input projectDir this one is taken
- * otherwise the default publish-please .sensitivedata file is taken
+ * If a .sensitivedata file is found in input projectDir, this one is taken
+ * otherwise the default publish-please .sensitivedata file is taken.
  * @param {string} projectDir - project directory to be analyzed by npm-pack command
  * @returns {DefaultSensitiveData}
  */

--- a/test/10-npm-audit-package-when-npm-version-gte-5.9.0.spec.js
+++ b/test/10-npm-audit-package-when-npm-version-gte-5.9.0.spec.js
@@ -28,8 +28,12 @@ if (nodeInfos.npmPackHasJsonReporter) {
             del.sync(pathJoin(projectDir, 'package.json'));
             del.sync(pathJoin(projectDir, 'package-lock.json'));
             del.sync(pathJoin(projectDir, '.publishrc'));
+            del.sync(pathJoin(projectDir, '.sensitivedata'));
+            del.sync(pathJoin(projectDir, '.npmignore'));
             del.sync(pathJoin(projectDir, '*.tgz'));
             del.sync(pathJoin(projectDir, 'lib', '*.tgz'));
+            del.sync(pathJoin(projectDir, 'yo', '*.tgz'));
+            del.sync(pathJoin(projectDir, 'yo', '*.js'));
             del.sync(pathJoin(projectDir, 'lib', 'test', '*.tgz'));
         });
         afterEach(() => {
@@ -65,6 +69,7 @@ if (nodeInfos.npmPackHasJsonReporter) {
                                 {
                                     path: 'package.json',
                                     size: 67,
+                                    isSensitiveData: false,
                                 },
                             ],
                             entryCount: 1,
@@ -243,6 +248,209 @@ if (nodeInfos.npmPackHasJsonReporter) {
                                 },
                             ],
                             entryCount: 4,
+                            bundled: [],
+                        };
+                        result.should.containDeep(expected);
+                    })
+            );
+        });
+
+        it('Should add sensitiva data corresponding to custom .sensitivedata on files included in the package', () => {
+            // Given
+            const pkg = {
+                name: 'testing-repo',
+                version: '0.0.0',
+                scripts: {},
+            };
+            writeFile(
+                pathJoin(projectDir, 'package.json'),
+                JSON.stringify(pkg, null, 2)
+            );
+            touch(pathJoin(projectDir, 'yo123.tgz'));
+            mkdirp.sync(pathJoin(projectDir, 'lib'));
+            touch(pathJoin(projectDir, 'lib', 'yo234.tgz'));
+            mkdirp.sync(pathJoin(projectDir, 'lib', 'test'));
+            touch(pathJoin(projectDir, 'lib', 'test', 'yo345.tgz'));
+            mkdirp.sync(pathJoin(projectDir, 'yo'));
+            touch(pathJoin(projectDir, 'yo', 'yo234.tgz'));
+            touch(pathJoin(projectDir, 'yo', 'keepit.js'));
+
+            const customSensitiveData = `
+            #-----------------------
+            # yo Files
+            #-----------------------
+            yo/**
+            **/yo/**
+            !yo/keepit.js
+            `;
+            writeFile(
+                pathJoin(projectDir, '.sensitivedata'),
+                customSensitiveData
+            );
+
+            const npmignore = `
+                .sensitivedata
+            `;
+            writeFile(pathJoin(projectDir, '.npmignore'), npmignore);
+
+            // When
+            return (
+                Promise.resolve()
+                    .then(() => auditPackage(projectDir))
+
+                    // Then
+                    .then((result) => {
+                        const expected = {
+                            id: 'testing-repo@0.0.0',
+                            name: 'testing-repo',
+                            version: '0.0.0',
+                            filename: 'testing-repo-0.0.0.tgz',
+                            files: [
+                                {
+                                    path: 'package.json',
+                                    size: 67,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'yo123.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'lib/yo234.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'lib/test/yo345.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'yo/keepit.js',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'yo/yo234.tgz',
+                                    size: 0,
+                                    isSensitiveData: true,
+                                },
+                            ],
+                            entryCount: 6,
+                            bundled: [],
+                        };
+                        result.should.containDeep(expected);
+                    })
+            );
+        });
+
+        it('Should set ignored files as non sensitive data on sensitiva data corresponding to custom .sensitivedata', () => {
+            // Given
+            const pkg = {
+                name: 'testing-repo',
+                version: '0.0.0',
+                scripts: {},
+            };
+            writeFile(
+                pathJoin(projectDir, 'package.json'),
+                JSON.stringify(pkg, null, 2)
+            );
+            touch(pathJoin(projectDir, 'yo123.tgz'));
+            mkdirp.sync(pathJoin(projectDir, 'lib'));
+            touch(pathJoin(projectDir, 'lib', 'yo234.tgz'));
+            mkdirp.sync(pathJoin(projectDir, 'lib', 'test'));
+            touch(pathJoin(projectDir, 'lib', 'test', 'yo345.tgz'));
+            mkdirp.sync(pathJoin(projectDir, 'yo'));
+            touch(pathJoin(projectDir, 'yo', 'yo234.tgz'));
+            touch(pathJoin(projectDir, 'yo', 'yo456.tgz'));
+            touch(pathJoin(projectDir, 'yo', 'keepit.js'));
+
+            const customSensitiveData = `
+            #-----------------------
+            # yo Files
+            #-----------------------
+            yo/**
+            **/yo/**
+            !yo/keepit.js
+            `;
+            writeFile(
+                pathJoin(projectDir, '.sensitivedata'),
+                customSensitiveData
+            );
+
+            const npmignore = `
+                .sensitivedata
+                .publishrc
+            `;
+            writeFile(pathJoin(projectDir, '.npmignore'), npmignore);
+
+            const config = {
+                validations: {
+                    sensitiveData: {
+                        ignore: ['yo/**/yo456.tgz'],
+                    },
+                },
+                confirm: true,
+                publishCommand: 'npm publish',
+                publishTag: 'latest',
+                postPublishScript: false,
+            };
+            writeFile(
+                pathJoin(projectDir, '.publishrc'),
+                JSON.stringify(config, null, 2)
+            );
+
+            // When
+            return (
+                Promise.resolve()
+                    .then(() => auditPackage(projectDir))
+
+                    // Then
+                    .then((result) => {
+                        const expected = {
+                            id: 'testing-repo@0.0.0',
+                            name: 'testing-repo',
+                            version: '0.0.0',
+                            filename: 'testing-repo-0.0.0.tgz',
+                            files: [
+                                {
+                                    path: 'package.json',
+                                    size: 67,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'yo123.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'lib/yo234.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'lib/test/yo345.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'yo/keepit.js',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                                {
+                                    path: 'yo/yo234.tgz',
+                                    size: 0,
+                                    isSensitiveData: true,
+                                },
+                                {
+                                    path: 'yo/yo456.tgz',
+                                    size: 0,
+                                    isSensitiveData: false,
+                                },
+                            ],
+                            entryCount: 7,
                             bundled: [],
                         };
                         result.should.containDeep(expected);

--- a/test/10-npm-audit-package.spec.js
+++ b/test/10-npm-audit-package.spec.js
@@ -718,8 +718,12 @@ describe('npm package analyzer', () => {
                     path: 'keys/foo_rsa.pub',
                     size: 123456,
                 },
+                {
+                    path: 'lib/keys/foo_rsa',
+                    size: 123456,
+                },
             ],
-            entryCount: 5,
+            entryCount: 6,
             bundled: [],
         };
         // When
@@ -757,8 +761,13 @@ describe('npm package analyzer', () => {
                     size: 123456,
                     isSensitiveData: false,
                 },
+                {
+                    path: 'lib/keys/foo_rsa',
+                    size: 123456,
+                    isSensitiveData: true,
+                },
             ],
-            entryCount: 5,
+            entryCount: 6,
             bundled: [],
         };
         result.should.containDeep(expected);

--- a/test/17-npx-integration-with-sensitive-data-validation-tests.js
+++ b/test/17-npx-integration-with-sensitive-data-validation-tests.js
@@ -344,6 +344,88 @@ describe('npx integration tests with sensitive-data validation', () => {
                     assert(!publishLog.includes('Sensitive or non essential data found in npm package: lib/test/yo234.spec.js'));
                 });
         });
+
+        it('Should detect custom .sensitivedata and ignore sensitive-data when sensitive-data check is enabled in .publishrc config file', () => {
+            return Promise.resolve()
+                .then(() => {
+                    writeFile(
+                        '.publishrc',
+                        JSON.stringify(
+                            {
+                                confirm: false,
+                                validations: {
+                                    vulnerableDependencies: false,
+                                    sensitiveData: {
+                                        ignore: ['**/yo456.tgz'],
+                                    },
+                                    uncommittedChanges: false,
+                                    untrackedFiles: false,
+                                    branch: 'master',
+                                    gitTag: false,
+                                },
+                                publishTag: 'latest',
+                                prePublishScript:
+                                    'echo "running script defined in .publishrc ..."',
+                                postPublishScript: false,
+                            },
+                            null,
+                            2
+                        )
+                    );
+                })
+                .then(() => {
+                    const customSensitiveData = `
+                    #-----------------------
+                    # yo Files
+                    #-----------------------
+                    yo/**
+                    **/yo/**
+                    !**/yo/keepit.js
+                    `;
+                    writeFile('.sensitivedata', customSensitiveData);
+                })
+                .then(() => {
+                    touch(pathJoin(process.cwd(), 'lib', 'yo234.tgz'));
+                    mkdirp.sync(pathJoin(process.cwd(), 'lib', 'yo'));
+                    touch(pathJoin(process.cwd(), 'lib', 'yo', 'yo234.tgz'));
+                    touch(pathJoin(process.cwd(), 'lib', 'yo', 'yo456.tgz'));
+                    touch(pathJoin(process.cwd(), 'lib', 'yo', 'keepit.js'));
+                })
+                .then(() => console.log(`> npx ${packageName}`))
+                .then(() =>
+                    exec(
+                        /* prettier-ignore */
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish11.log`
+                    )
+                )
+                .then(() => {
+                    const publishLog = readFile('./publish11.log').toString();
+                    console.log(publishLog);
+                    return publishLog;
+                })
+                .then((publishLog) => {
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running pre-publish script'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('running script defined in .publishrc ...'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running validations'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Checking for the sensitive and non-essential data in the npm package'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Validating branch'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('ERRORS'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Sensitive or non essential data found in npm package: lib/yo/yo234.tgz'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('Sensitive or non essential data found in npm package: lib/yo234.tgz'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('Sensitive or non essential data found in npm package: lib/yo/yo456.tgz'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('Sensitive or non essential data found in npm package: lib/yo/keepit.js'));
+                });
+        });
     }
 
     if (!nodeInfos.npmPackHasJsonReporter) {
@@ -399,11 +481,11 @@ describe('npx integration tests with sensitive-data validation', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish11.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish12.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish11.log').toString();
+                    const publishLog = readFile('./publish12.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })

--- a/test/17-npx-integration-with-sensitive-data-validation-tests.js
+++ b/test/17-npx-integration-with-sensitive-data-validation-tests.js
@@ -138,11 +138,11 @@ describe('npx integration tests with sensitive-data validation', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish09.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish11.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish09.log').toString();
+                    const publishLog = readFile('./publish11.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })
@@ -233,11 +233,11 @@ describe('npx integration tests with sensitive-data validation', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish09.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish12.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish09.log').toString();
+                    const publishLog = readFile('./publish12.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })
@@ -313,11 +313,11 @@ describe('npx integration tests with sensitive-data validation', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish10.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish13.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish10.log').toString();
+                    const publishLog = readFile('./publish13.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })
@@ -395,11 +395,11 @@ describe('npx integration tests with sensitive-data validation', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish11.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish14.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish11.log').toString();
+                    const publishLog = readFile('./publish14.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })
@@ -481,11 +481,11 @@ describe('npx integration tests with sensitive-data validation', () => {
                 .then(() =>
                     exec(
                         /* prettier-ignore */
-                        `npx ../${packageName.replace('@','-')}.tgz > ./publish12.log`
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish15.log`
                     )
                 )
                 .then(() => {
-                    const publishLog = readFile('./publish12.log').toString();
+                    const publishLog = readFile('./publish15.log').toString();
                     console.log(publishLog);
                     return publishLog;
                 })


### PR DESCRIPTION
The goal of this PR is to enhance the sensitive and non-essential data validation, in order to be able to  override the internal `.sensitivedata` file, as explained in #75.

With this new feature, the sensitive and non-essential data validation could be fully customised on a per project basis because there can be some files that are okay to publish and vice versa.

In order to customise this validation, you will have to create a `.sensitivedata` file at the root of your project and put in that file what you consider as being sensitive. 

Use [this file](https://github.com/inikulin/publish-please/blob/master/.sensitivedata) as reference.

