### PR TITLE
[WIP]: dry-run workflow should not prompt for user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [5.4.0] - 2018-11-29
+### Unreleased
+- dry-run workflow should not prompt for user input
+### Fixed
+- tgz file is left in project directory after successfull dry-run 
+
 ## [5.3.0] - 2018-11-21
 ### Added
 - add a CI reporter and be able to automatically switch from elegant status reporter to CI reporter when running on CI 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
The goal of this PR is to be able to use the dry-run workflow as a tool to automatically validate a package before publishing to the registry:

```sh
npx publish-please --dry-run
```
or

```sh
npm run publish-please --dry-run
```

will exit a zero code when the validation is successfull and will exit with 1 otherwise.
