### PR TITLE
feat(git-tag): add the ability to use a tag prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [5.5.0] - 2019-07-01
 ### Added
-- add the ability to use a tag prefix 
+- add the ability to use a tag prefix (by [Fredrik Wollsén](https://github.com/motin))
 
 ## [5.4.3] - 2018-12-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [5.5.0] - 2019-07-01
+### Added
+- add the ability to use a tag prefix 
+
 ## [5.4.3] - 2018-12-02
 ### Changed
 - align the README with all previous changes 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ When all validations pass, publish-please will show you the exact content of the
         }
          ```
 
-    - if the git tag contains a prefix to the version like for example `foo-v0.0.42`, the only way for the git tag validation to work is to setup this prefix in the `.publishrc` file:
+    - if the git tag contains a prefix to the version like for example `foo-v0.0.42`, supply the prefix in the `.publishrc` file:
 
         ```json
         {

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ When all validations pass, publish-please will show you the exact content of the
         }
          ```
 
+    - if the git tag contains a prefix to the version like for example `foo-v0.0.42`, the only way for the git tag validation to work is to setup this prefix in the `.publishrc` file:
+
+        ```json
+        {
+            "validations": {
+                "gitTag": "foo-v",
+            }
+        }
+        ```
+
 -------------------------------------------------------------
 ## Publish to the registry on sucessfull validation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-please",
-  "version": "5.4.3",
+  "version": "5.5.0",
   "description": "Safe and highly functional replacement for `npm publish`.",
   "main": "./lib/index.js",
   "bin": {

--- a/src/validations/git-tag.js
+++ b/src/validations/git-tag.js
@@ -16,7 +16,7 @@ module.exports = {
         );
     },
     canRun: () => true,
-    run(_, pkg) {
+    run(booleanOrPrefix, pkg) {
         return exec('git describe --exact-match --tags HEAD')
             .catch(() => {
                 throw "Latest commit doesn't have git tag.";
@@ -24,8 +24,13 @@ module.exports = {
             .then((tag) => {
                 const version = pkg.version;
 
-                if (tag !== version && tag !== 'v' + version)
-                    throw `Expected git tag to be '${version}' or 'v${version}', but it was '${tag}'.`;
+                const prefix =
+                    typeof booleanOrPrefix === 'boolean'
+                        ? 'v'
+                        : booleanOrPrefix;
+
+                if (tag !== version && tag !== `${prefix}${version}`)
+                    throw `Expected git tag to be '${version}' or '${prefix}${version}', but it was '${tag}'.`;
             });
     },
 };

--- a/src/validations/vulnerable-dependencies.js
+++ b/src/validations/vulnerable-dependencies.js
@@ -35,13 +35,17 @@ module.exports = {
                 audit(projectDir)
                     .then((result) => {
                         if (vulnerabilitiesFoundIn(result)) {
-                            const errs = [];
+                            const errs = new Set();
                             result.actions.forEach((action) => {
                                 action.resolves.forEach((vulnerability) => {
-                                    errs.push(summaryOf(vulnerability));
+                                    errs.add(summaryOf(vulnerability));
                                 });
                             });
-                            reject(errs.sort());
+                            const distinctAndSortedErrors = Array.from(
+                                errs
+                            ).sort();
+
+                            reject(distinctAndSortedErrors);
                             return;
                         }
                         if (auditErrorFoundIn(result)) {

--- a/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
+++ b/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
@@ -1016,6 +1016,13 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     isMajor: false,
                                     resolves: [
                                         {
+                                            id: 782,
+                                            path: 'lodash',
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
                                             id: 577,
                                             path: 'lodash',
                                             dev: true,
@@ -1031,6 +1038,13 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     target: '4.17.11',
                                     resolves: [
                                         {
+                                            id: 782,
+                                            path: 'nsp>inquirer>lodash',
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
                                             id: 577,
                                             path: 'nsp>inquirer>lodash',
                                             dev: true,
@@ -1043,6 +1057,21 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     action: 'review',
                                     module: 'lodash',
                                     resolves: [
+                                        {
+                                            id: 782,
+                                            path:
+                                                'ban-sensitive-files>ggit>lodash',
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            id: 782,
+                                            path: 'nsp>cli-table2>lodash',
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
                                         {
                                             id: 577,
                                             path:
@@ -1122,6 +1151,68 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     },
                                     url: 'https://npmjs.com/advisories/577',
                                 },
+                                '782': {
+                                    findings: [
+                                        {
+                                            version: '4.17.4',
+                                            paths: [
+                                                'ban-sensitive-files>ggit>lodash',
+                                            ],
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            version: '4.16.4',
+                                            paths: [
+                                                'lodash',
+                                                'nsp>inquirer>lodash',
+                                            ],
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            version: '3.10.1',
+                                            paths: ['nsp>cli-table2>lodash'],
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                    ],
+                                    id: 782,
+                                    created: '2019-02-13T16:16:53.770Z',
+                                    updated: '2019-06-27T14:01:44.172Z',
+                                    deleted: null,
+                                    title: 'Prototype Pollution',
+                                    found_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    reported_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    module_name: 'lodash',
+                                    cves: ['CVE-2018-16487'],
+                                    vulnerable_versions: '<4.17.11',
+                                    patched_versions: '>=4.17.11',
+                                    overview:
+                                        "Versions of `lodash` before 4.17.5 are vulnerable to prototype pollution. \n\nThe vulnerable functions are 'defaultsDeep', 'merge', and 'mergeWith' which allow a malicious user to modify the prototype of `Object` via `{constructor: {prototype: {...}}}` causing the addition or modification of an existing property that will exist on all objects.\n\n",
+                                    recommendation:
+                                        'Update to version 4.17.11 or later.',
+                                    references:
+                                        '- [HackerOne Report](https://hackerone.com/reports/380873)',
+                                    access: 'public',
+                                    severity: 'high',
+                                    cwe: 'CWE-471',
+                                    metadata: {
+                                        module_type: '',
+                                        exploitability: 3,
+                                        affected_components: '',
+                                    },
+                                    url: 'https://npmjs.com/advisories/782',
+                                },
                             },
                             muted: [],
                             metadata: {
@@ -1129,7 +1220,7 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     info: 0,
                                     low: 4,
                                     moderate: 0,
-                                    high: 0,
+                                    high: 4,
                                     critical: 0,
                                 },
                                 dependencies: 164,

--- a/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
+++ b/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
@@ -757,6 +757,13 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     isMajor: false,
                                     resolves: [
                                         {
+                                            id: 782,
+                                            path: 'lodash',
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
                                             id: 577,
                                             path: 'lodash',
                                             dev: true,
@@ -772,6 +779,13 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     target: '4.17.11',
                                     resolves: [
                                         {
+                                            id: 782,
+                                            path: 'nsp>inquirer>lodash',
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
                                             id: 577,
                                             path: 'nsp>inquirer>lodash',
                                             dev: true,
@@ -784,6 +798,21 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     action: 'review',
                                     module: 'lodash',
                                     resolves: [
+                                        {
+                                            id: 782,
+                                            path:
+                                                'ban-sensitive-files>ggit>lodash',
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            id: 782,
+                                            path: 'nsp>cli-table2>lodash',
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
                                         {
                                             id: 577,
                                             path:
@@ -863,6 +892,68 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     },
                                     url: 'https://npmjs.com/advisories/577',
                                 },
+                                '782': {
+                                    findings: [
+                                        {
+                                            version: '4.17.4',
+                                            paths: [
+                                                'ban-sensitive-files>ggit>lodash',
+                                            ],
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            version: '4.16.4',
+                                            paths: [
+                                                'lodash',
+                                                'nsp>inquirer>lodash',
+                                            ],
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            version: '3.10.1',
+                                            paths: ['nsp>cli-table2>lodash'],
+                                            dev: true,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                    ],
+                                    id: 782,
+                                    created: '2019-02-13T16:16:53.770Z',
+                                    updated: '2019-06-27T14:01:44.172Z',
+                                    deleted: null,
+                                    title: 'Prototype Pollution',
+                                    found_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    reported_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    module_name: 'lodash',
+                                    cves: ['CVE-2018-16487'],
+                                    vulnerable_versions: '<4.17.11',
+                                    patched_versions: '>=4.17.11',
+                                    overview:
+                                        "Versions of `lodash` before 4.17.5 are vulnerable to prototype pollution. \n\nThe vulnerable functions are 'defaultsDeep', 'merge', and 'mergeWith' which allow a malicious user to modify the prototype of `Object` via `{constructor: {prototype: {...}}}` causing the addition or modification of an existing property that will exist on all objects.\n\n",
+                                    recommendation:
+                                        'Update to version 4.17.11 or later.',
+                                    references:
+                                        '- [HackerOne Report](https://hackerone.com/reports/380873)',
+                                    access: 'public',
+                                    severity: 'high',
+                                    cwe: 'CWE-471',
+                                    metadata: {
+                                        module_type: '',
+                                        exploitability: 3,
+                                        affected_components: '',
+                                    },
+                                    url: 'https://npmjs.com/advisories/782',
+                                },
                             },
                             muted: [],
                             metadata: {
@@ -870,7 +961,7 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     info: 0,
                                     low: 4,
                                     moderate: 0,
-                                    high: 0,
+                                    high: 4,
                                     critical: 0,
                                 },
                                 dependencies: 164,

--- a/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
+++ b/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
@@ -344,6 +344,13 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     target: '4.17.11',
                                     resolves: [
                                         {
+                                            id: 782,
+                                            path: 'nsp>inquirer>lodash',
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
                                             id: 577,
                                             path: 'nsp>inquirer>lodash',
                                             dev: false,
@@ -356,6 +363,21 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     action: 'review',
                                     module: 'lodash',
                                     resolves: [
+                                        {
+                                            id: 782,
+                                            path:
+                                                'ban-sensitive-files>ggit>lodash',
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            id: 782,
+                                            path: 'nsp>cli-table2>lodash',
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
                                         {
                                             id: 577,
                                             path:
@@ -426,6 +448,59 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     },
                                     url: 'https://npmjs.com/advisories/577',
                                 },
+                                '782': {
+                                    findings: [
+                                        {
+                                            version: '4.17.4',
+                                            paths: [
+                                                'ban-sensitive-files>ggit>lodash',
+                                                'nsp>inquirer>lodash',
+                                            ],
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
+                                            version: '3.10.1',
+                                            paths: ['nsp>cli-table2>lodash'],
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                    ],
+                                    id: 782,
+                                    created: '2019-02-13T16:16:53.770Z',
+                                    updated: '2019-06-27T14:01:44.172Z',
+                                    deleted: null,
+                                    title: 'Prototype Pollution',
+                                    found_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    reported_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    module_name: 'lodash',
+                                    cves: ['CVE-2018-16487'],
+                                    vulnerable_versions: '<4.17.11',
+                                    patched_versions: '>=4.17.11',
+                                    overview:
+                                        "Versions of `lodash` before 4.17.5 are vulnerable to prototype pollution. \n\nThe vulnerable functions are 'defaultsDeep', 'merge', and 'mergeWith' which allow a malicious user to modify the prototype of `Object` via `{constructor: {prototype: {...}}}` causing the addition or modification of an existing property that will exist on all objects.\n\n",
+                                    recommendation:
+                                        'Update to version 4.17.11 or later.',
+                                    references:
+                                        '- [HackerOne Report](https://hackerone.com/reports/380873)',
+                                    access: 'public',
+                                    severity: 'high',
+                                    cwe: 'CWE-471',
+                                    metadata: {
+                                        module_type: '',
+                                        exploitability: 3,
+                                        affected_components: '',
+                                    },
+                                    url: 'https://npmjs.com/advisories/782',
+                                },
                             },
                             muted: [],
                             metadata: {
@@ -433,7 +508,7 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     info: 0,
                                     low: 3,
                                     moderate: 0,
-                                    high: 0,
+                                    high: 3,
                                     critical: 0,
                                 },
                                 dependencies: 315,

--- a/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
+++ b/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
@@ -550,6 +550,13 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     isMajor: false,
                                     resolves: [
                                         {
+                                            id: 782,
+                                            path: 'lodash',
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                        {
                                             id: 577,
                                             path: 'lodash',
                                             dev: false,
@@ -601,6 +608,49 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     },
                                     url: 'https://npmjs.com/advisories/577',
                                 },
+                                '782': {
+                                    findings: [
+                                        {
+                                            version: '4.16.4',
+                                            paths: ['lodash'],
+                                            dev: false,
+                                            optional: false,
+                                            bundled: false,
+                                        },
+                                    ],
+                                    id: 782,
+                                    created: '2019-02-13T16:16:53.770Z',
+                                    updated: '2019-06-27T14:01:44.172Z',
+                                    deleted: null,
+                                    title: 'Prototype Pollution',
+                                    found_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    reported_by: {
+                                        link: '',
+                                        name: 'asgerf',
+                                    },
+                                    module_name: 'lodash',
+                                    cves: ['CVE-2018-16487'],
+                                    vulnerable_versions: '<4.17.11',
+                                    patched_versions: '>=4.17.11',
+                                    overview:
+                                        "Versions of `lodash` before 4.17.5 are vulnerable to prototype pollution. \n\nThe vulnerable functions are 'defaultsDeep', 'merge', and 'mergeWith' which allow a malicious user to modify the prototype of `Object` via `{constructor: {prototype: {...}}}` causing the addition or modification of an existing property that will exist on all objects.\n\n",
+                                    recommendation:
+                                        'Update to version 4.17.11 or later.',
+                                    references:
+                                        '- [HackerOne Report](https://hackerone.com/reports/380873)',
+                                    access: 'public',
+                                    severity: 'high',
+                                    cwe: 'CWE-471',
+                                    metadata: {
+                                        module_type: '',
+                                        exploitability: 3,
+                                        affected_components: '',
+                                    },
+                                    url: 'https://npmjs.com/advisories/782',
+                                },
                             },
                             muted: [],
                             metadata: {
@@ -608,7 +658,7 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                     info: 0,
                                     low: 1,
                                     moderate: 0,
-                                    high: 0,
+                                    high: 1,
                                     critical: 0,
                                 },
                                 dependencies: 1,

--- a/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
+++ b/test/09-npm-audit-when-npm-version-gte-6.1.0.spec.js
@@ -239,7 +239,7 @@ if (nodeInfos.npmAuditHasJsonReporter) {
                                 {
                                     action: 'install',
                                     module: 'ms',
-                                    target: '2.1.1',
+                                    target: '2.1.2',
                                     isMajor: true,
                                     resolves: [
                                         {

--- a/test/13-integration-tests.js
+++ b/test/13-integration-tests.js
@@ -1171,7 +1171,7 @@ describe('Integration tests', () => {
                     return assert(err.message.indexOf(GUARD_ERROR) >= 0);
                 }));
 
-        it.only('Should allow publishing with special flag', () =>
+        it('Should allow publishing with special flag', () =>
             exec('npm publish --with-publish-please')
                 // NOTE: it will reject anyway because this package version already
                 // published or test host don't have permissions to do that
@@ -1179,7 +1179,6 @@ describe('Integration tests', () => {
                     throw new Error('Promise rejection expected');
                 })
                 .catch((err) => {
-                    console.log(err.message);
                     // prettier-ignore
                     assert(
                         err.message.indexOf('You do not have permission to publish') > -1 ||

--- a/test/13-integration-tests.js
+++ b/test/13-integration-tests.js
@@ -1184,7 +1184,8 @@ describe('Integration tests', () => {
                     assert(
                         err.message.indexOf('You do not have permission to publish') > -1 ||
                         err.message.indexOf('auth required for publishing') > -1 ||
-                        err.message.indexOf('operation not permitted') > -1
+                        err.message.indexOf('operation not permitted') > -1 ||
+                        err.message.indexOf('You must be logged in to publish packages') > -1
                     );
                 }));
 

--- a/test/13-integration-tests.js
+++ b/test/13-integration-tests.js
@@ -1171,7 +1171,7 @@ describe('Integration tests', () => {
                     return assert(err.message.indexOf(GUARD_ERROR) >= 0);
                 }));
 
-        it('Should allow publishing with special flag', () =>
+        it.only('Should allow publishing with special flag', () =>
             exec('npm publish --with-publish-please')
                 // NOTE: it will reject anyway because this package version already
                 // published or test host don't have permissions to do that
@@ -1179,6 +1179,7 @@ describe('Integration tests', () => {
                     throw new Error('Promise rejection expected');
                 })
                 .catch((err) => {
+                    console.log(err.message);
                     // prettier-ignore
                     assert(
                         err.message.indexOf('You do not have permission to publish') > -1 ||

--- a/test/13-integration-tests.js
+++ b/test/13-integration-tests.js
@@ -862,7 +862,7 @@ describe('Integration tests', () => {
                         )
                     ));
 
-            ['lodash@4.17.5', 'ms@0.7.1'].forEach(function(dependency) {
+            ['lodash@4.17.11', 'ms@0.7.1'].forEach(function(dependency) {
                 const name = dependency.split('@')[0];
                 const version = dependency.split('@')[1];
                 it(`Should not fail on ${dependency} as a direct dependency`, () =>

--- a/test/13-integration-tests.js
+++ b/test/13-integration-tests.js
@@ -843,7 +843,10 @@ describe('Integration tests', () => {
                         writeFile('package.json', JSON.stringify(pkg));
                         writeFile(
                             '.auditignore',
-                            ['https://npmjs.com/advisories/577'].join(EOL)
+                            [
+                                'https://npmjs.com/advisories/577',
+                                'https://npmjs.com/advisories/782',
+                            ].join(EOL)
                         );
                     })
                     .then(() =>

--- a/test/13-integration-tests.js
+++ b/test/13-integration-tests.js
@@ -376,6 +376,30 @@ describe('Integration tests', () => {
                     )
                 ));
 
+        it('Should expect prefixed git tag to match version', () =>
+            exec('git checkout master')
+                .then(() => exec('git tag foo-v0.0.42'))
+                .then(() =>
+                    publish(
+                        getTestOptions({
+                            set: {
+                                validations: {
+                                    gitTag: 'foo-v',
+                                },
+                            },
+                        })
+                    )
+                )
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch((err) =>
+                    assert.strictEqual(
+                        err.message,
+                        "  * Expected git tag to be '1.3.77' or 'foo-v1.3.77', but it was 'foo-v0.0.42'."
+                    )
+                ));
+
         it('Should expect git tag to exist', () =>
             exec('git checkout master')
                 .then(() =>
@@ -409,6 +433,22 @@ describe('Integration tests', () => {
                                 publishCommand: echoPublishCommand,
                                 validations: {
                                     gitTag: true,
+                                },
+                            },
+                        })
+                    )
+                ));
+
+        it('Should pass validation when prefixed', () =>
+            exec('git checkout master')
+                .then(() => exec('git tag foo-v1.3.77'))
+                .then(() =>
+                    publish(
+                        getTestOptions({
+                            set: {
+                                publishCommand: echoPublishCommand,
+                                validations: {
+                                    gitTag: 'foo-v',
                                 },
                             },
                         })

--- a/test/16-npx-integration-with-npm-audit-tests.js
+++ b/test/16-npx-integration-with-npm-audit-tests.js
@@ -271,10 +271,9 @@ describe('npx integration tests with npm audit', () => {
                     writeFile('package.json', JSON.stringify(pkg, null, 2));
                 })
                 .then(() => {
+                    // will remove low+moderate+high vulnerabilities
                     const auditOptions = `
-                        --debug
-                        --audit-level=critical  
-                        --json
+                        --audit-level=critical 
                         `;
                     writeFile('audit.opts', auditOptions);
                 })
@@ -323,6 +322,90 @@ describe('npx integration tests with npm audit', () => {
                     assert(publishLog.includes('Release info'));
                     /* prettier-ignore */
                     assert(publishLog.includes('Command `npm` exited with code'));
+                });
+        });
+
+        it('Should not publish when --audit-level is set to high and vulnerability check is enabled in .publishrc config file', () => {
+            return Promise.resolve()
+                .then(() => {
+                    writeFile(
+                        '.publishrc',
+                        JSON.stringify({
+                            confirm: false,
+                            validations: {
+                                vulnerableDependencies: true,
+                                sensitiveData: false,
+                                uncommittedChanges: false,
+                                untrackedFiles: false,
+                                branch: 'master',
+                                gitTag: false,
+                            },
+                            publishTag: 'latest',
+                            prePublishScript:
+                                'echo "running script defined in .publishrc ..."',
+                            postPublishScript: false,
+                        })
+                    );
+                })
+                .then(() => {
+                    const pkg = JSON.parse(readFile('package.json').toString());
+                    pkg.dependencies = {
+                        'publish-please': '2.4.1',
+                    };
+                    writeFile('package.json', JSON.stringify(pkg, null, 2));
+                })
+                .then(() => {
+                    // will remove low+moderate vulnerabilities
+                    const auditOptions = `
+                        --audit-level=high 
+                        `;
+                    writeFile('audit.opts', auditOptions);
+                })
+                .then(() => console.log(`> npx ${packageName}`))
+                .then(() =>
+                    exec(
+                        /* prettier-ignore */
+                        `npx ../${packageName.replace('@','-')}.tgz > ./publish10.log`
+                    )
+                )
+                .then(() => {
+                    const publishLog = readFile('./publish10.log').toString();
+                    console.log(publishLog);
+                    return publishLog;
+                })
+                .then((publishLog) => {
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running pre-publish script'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('running script defined in .publishrc ...'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Running validations'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Checking for the vulnerable dependencies'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('Validating branch'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('ERRORS'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('publish-please -> ban-sensitive-files -> ggit -> lodash'));
+                    /* prettier-ignore */
+                    assert(publishLog.includes('publish-please -> nsp -> https-proxy-agent'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('publish-please -> nsp -> joi -> hoek'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('publish-please -> nsp -> joi -> moment'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('publish-please -> nsp -> joi -> topo -> hoek'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('publish-please -> nsp -> rc -> deep-extend'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('publish-please -> nsp -> wreck -> boom -> hoek'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('publish-please -> nsp -> wreck -> hoek'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('Release info'));
+                    /* prettier-ignore */
+                    assert(!publishLog.includes('Command `npm` exited with code'));
                 });
         });
     }

--- a/test/16-npx-integration-with-npm-audit-tests.js
+++ b/test/16-npx-integration-with-npm-audit-tests.js
@@ -186,14 +186,14 @@ describe('npx integration tests with npm audit', () => {
                     writeFile('package.json', JSON.stringify(pkg, null, 2));
                 })
                 .then(() => {
+                    // will remove low vulnerabilities
                     const auditOptions = `
-                        --debug
-                        --audit-level=moderate  
-                        --json
+                        --audit-level=moderate
                         `;
                     writeFile('audit.opts', auditOptions);
                 })
                 .then(() => {
+                    // will remove moderate vulnerabilities with advisories 566
                     const auditIgnore = ['https://npmjs.com/advisories/566'];
                     writeFile('.auditignore', auditIgnore.join(EOL));
                 })
@@ -223,11 +223,11 @@ describe('npx integration tests with npm audit', () => {
                     /* prettier-ignore */
                     assert(publishLog.includes('ERRORS'));
                     /* prettier-ignore */
-                    assert(!publishLog.includes('publish-please -> ban-sensitive-files -> ggit -> lodash'));
+                    assert(publishLog.includes('publish-please -> ban-sensitive-files -> ggit -> lodash'));
                     /* prettier-ignore */
                     assert(publishLog.includes('publish-please -> nsp -> https-proxy-agent'));
                     /* prettier-ignore */
-                    assert(! publishLog.includes('publish-please -> nsp -> joi -> hoek'));
+                    assert(!publishLog.includes('publish-please -> nsp -> joi -> hoek'));
                     /* prettier-ignore */
                     assert(!publishLog.includes('publish-please -> nsp -> joi -> moment'));
                     /* prettier-ignore */


### PR DESCRIPTION
This is useful for monorepos that includes the source code to several npm packages, all of which are tagged in Git using a separate prefix.