### PR TITLE
Bump lodash to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "elegant-status": "1.1.0",
     "inquirer": "6.2.0",
     "is-ci": "1.2.1",
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "micromatch": "3.1.10",
     "node-emoji": "1.8.1",
     "osenv": "0.1.5",


### PR DESCRIPTION
lodash 4.17.20 is flagged as a security issue by npm