### PR TITLE
Pin production dependencies to be semver-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,16 +47,16 @@
     ".sensitivedata"
   ],
   "dependencies": {
-    "chalk": "2.4.1",
-    "cp-sugar": "1.0.0",
-    "elegant-status": "1.1.0",
-    "inquirer": "6.2.0",
-    "is-ci": "1.2.1",
-    "lodash": "4.17.20",
-    "micromatch": "3.1.10",
-    "node-emoji": "1.8.1",
-    "osenv": "0.1.5",
-    "semver": "5.6.0"
+    "chalk": "^2.4.1",
+    "cp-sugar": "^1.0.0",
+    "elegant-status": "^1.1.0",
+    "inquirer": "^6.2.0",
+    "is-ci": "^1.2.1",
+    "lodash": "^4.17.20",
+    "micromatch": "^3.1.10",
+    "node-emoji": "^1.8.1",
+    "osenv": "^0.1.5",
+    "semver": "^5.6.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION
This should reduce the frequency publish-please needs to be updated for dependency-vulnerabilities, allowing dependents to use `npm audit fix` (or their preferred package manager, or patch their lockfiles as necessary) without changes to this package.